### PR TITLE
Allow for in-place fragments if file locking is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 # The MIT License
 #
 # Copyright (c) 2016 MIT and Intel Corporation
+# Copyright (c) 2018-2019 Omics Data Automation, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -44,7 +45,7 @@ set(ENABLE_MUPARSERX_EXPRESSIONS False CACHE BOOL "Enable MuparserX expression p
 set(LIBUUID_DIR "" CACHE PATH "Path to libuuid install directory")
 set(HDFS_SOURCE_DIR "deps/HDFSWrapper/hadoop-hdfs-native" CACHE PATH "Path to modified libhdfs source dir")
 
-# Only for Mac OS X warnings
+# Only for Mac OS X
 if(APPLE)
   set(CMAKE_MACOSX_RPATH True CACHE BOOL "Set rpath on OSX")
   set(CMAKE_FIND_FRAMEWORK NEVER CACHE STRING "Never try to find frameworks on Mac OS X")
@@ -64,7 +65,6 @@ set(MAC_ADDRESS_INTERFACE ""
 )
 set(USE_PARALLEL_SORT False CACHE BOOL "Enables parallel sorting.")
 set(USE_HDFS True CACHE BOOL "Enables HDFS support")
-set(GTEST_FILTER "*" CACHE STRING "Filters for the Google unit tests.")
 set(COMPRESSION_LEVEL_GZIP "" CACHE STRING "Compression level for GZIP.")
 set(COMPRESSION_LEVEL_ZSTD "" CACHE STRING "Compression level for Zstandard.")
 set(COMPRESSION_LEVEL_BLOSC "" CACHE STRING "Compression level for Blosc.")

--- a/core/include/storage_manager/storage_fs.h
+++ b/core/include/storage_manager/storage_fs.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation Inc. and Intel Corporation
+ * @copyright Copyright (c) 2018-2019 Omics Data Automation Inc. and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -92,6 +92,7 @@ class StorageFS {
   bool disable_file_locking();
  private:
   bool disable_file_locking_;
+  bool is_disable_file_locking_set = false;
 };
 
 #endif /* __STORAGE_FS_H__ */

--- a/core/include/storage_manager/storage_manager_config.h
+++ b/core/include/storage_manager/storage_manager_config.h
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -196,11 +197,6 @@ class StorageManagerConfig {
    *      TileDB will use MPI-IO write. 
    */
   int write_method_;
-
-  /*
-   * Disable file locking even if the backend supports it
-   */
-  bool disable_file_locking_;
 
   /** The Filesystem type associated with this configuration */
   StorageFS *fs_ = NULL;

--- a/core/src/array/array.cc
+++ b/core/src/array/array.cc
@@ -6,6 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -1297,16 +1298,16 @@ std::string Array::new_fragment_name() const {
   std::string mac = uuid_str;
 #endif
 
-  // Generate fragment name. Note that the cloud based filesystems have
-  // fragment names generated "in-place", there will be no rename associated
-  // with those fragments.
+  // Generate fragment name. Note: for cloud based filesystems or if locking_support is
+  // turned off explicitly, fragment names are generated "in-place", there will be no
+  // rename associated with those fragments.
   int n;
-  if (is_hdfs_path(get_array_path_used()) || is_gcs_path(get_array_path_used())) {
-    n = sprintf(fragment_name, "%s/__%s%" PRIu64"_%" PRIu64,
-              get_array_path_used().c_str(), mac.c_str(), tid, ms);  
+  if (config()->get_filesystem()->locking_support()) {
+    n = sprintf(fragment_name, "%s/.__%s%" PRIu64"_%" PRIu64,
+		get_array_path_used().c_str(), mac.c_str(), tid, ms);
   } else {
-      n = sprintf(fragment_name, "%s/.__%s%" PRIu64"_%" PRIu64,
-          get_array_path_used().c_str(), mac.c_str(), tid, ms);
+    n = sprintf(fragment_name, "%s/__%s%" PRIu64"_%" PRIu64,
+		get_array_path_used().c_str(), mac.c_str(), tid, ms);
   }
 
   // Handle error

--- a/core/src/fragment/fragment.cc
+++ b/core/src/fragment/fragment.cc
@@ -6,6 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -304,12 +305,12 @@ int Fragment::rename_fragment() {
   if(read_mode())
     return TILEDB_FG_OK;
 
-  // No rename of fragment required for cloud based filenames
-  if (is_hdfs_path(fragment_name_) || is_gcs_path(fragment_name_)) {
+  StorageFS *fs = array_->config()->get_filesystem();
+
+  // No rename of fragment for filesystems with no locking
+  if (!fs->locking_support()) {
     return TILEDB_FG_OK;
   }
-
-  StorageFS *fs = array_->config()->get_filesystem();
 
   std::string parent_dir = ::parent_dir(fs, fragment_name_);
   std::string new_fragment_name = parent_dir + "/" +

--- a/core/src/misc/utils.cc
+++ b/core/src/misc/utils.cc
@@ -6,7 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/storage_manager/storage_fs.cc
+++ b/core/src/storage_manager/storage_fs.cc
@@ -58,8 +58,6 @@ void StorageFS::set_disable_file_locking(const bool val) {
   disable_file_locking_ = val;
 }
 
-bool is_disable_file_locking_set = false;
-
 bool StorageFS::disable_file_locking() {
   if (is_disable_file_locking_set) {
     return disable_file_locking_;

--- a/core/src/storage_manager/storage_fs.cc
+++ b/core/src/storage_manager/storage_fs.cc
@@ -5,6 +5,8 @@
  *
  * The MIT License
  *
+ * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -56,13 +58,23 @@ void StorageFS::set_disable_file_locking(const bool val) {
   disable_file_locking_ = val;
 }
 
+bool is_disable_file_locking_set = false;
+
 bool StorageFS::disable_file_locking() {
+  if (is_disable_file_locking_set) {
+    return disable_file_locking_;
+  }
+
+  is_disable_file_locking_set = true;
+
   if(disable_file_locking_)
     return true;
+
   auto env_var = getenv("TILEDB_DISABLE_FILE_LOCKING");
   if(env_var && (strcasecmp(env_var, "true") == 0 || strcmp(env_var, "1") == 0)) {
     disable_file_locking_ = true;
     return true;
   }
+  disable_file_locking_ = false;
   return false;
 }

--- a/core/src/storage_manager/storage_hdfs.cc
+++ b/core/src/storage_manager/storage_hdfs.cc
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2018 University of California, Los Angeles and Intel Corporation
+ * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -416,6 +417,8 @@ static int read_from_file_kernel(hdfsFS hdfs_handle, hdfsFile file, void* buffer
     tSize bytes_read = hdfsRead(hdfs_handle, file, (void *)pbuf,  (length - nbytes) > max_bytes ? max_bytes : length - nbytes);
     if (bytes_read < 0) {
       return print_errmsg(std::string("Error reading file. ") + std::strerror(errno));
+    } else if (bytes_read == 0) {
+      return print_errmsg(std::string("EOF reached"));
     }
     nbytes += bytes_read;
     pbuf += bytes_read;
@@ -578,15 +581,8 @@ int HDFS::close_file(const std::string& filename) {
   return rc_close_write;
 }
 
-static bool done_printing_consolidation_support_message = false;
-
 bool HDFS::locking_support() {
-  if(disable_file_locking())
-    return false;
-  if (!done_printing_consolidation_support_message) {
-    print_errmsg("No file locking support for HDFS/GCS/EMRFS paths.");
-    done_printing_consolidation_support_message = true;
-  }
+  // No file locking available for distributed file systems
   return false;
 }
 

--- a/core/src/storage_manager/storage_manager.cc
+++ b/core/src/storage_manager/storage_manager.cc
@@ -6,6 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -1584,6 +1585,13 @@ int StorageManager::consolidation_filelock_lock(
   std::string filename = 
       array_name_real + "/" + 
       TILEDB_SM_CONSOLIDATION_FILELOCK_NAME;
+
+  // Create consolidation lock file if necessary
+  if (!fs_->is_file(filename)) {
+    if (!consolidation_filelock_create(array_name_real)) {
+      return TILEDB_SM_ERR;
+    }
+  }
 
   // Open the file
   fd = ::open(filename.c_str(), O_RDWR);

--- a/core/src/storage_manager/storage_manager_config.cc
+++ b/core/src/storage_manager/storage_manager_config.cc
@@ -6,6 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/storage_manager/storage_posixfs.cc
+++ b/core/src/storage_manager/storage_posixfs.cc
@@ -353,11 +353,11 @@ int PosixFS::read_from_file(const std::string& filename, off_t offset, void *buf
     return TILEDB_FS_ERR;
   }
 
-  // Read in batches of SSIZE_MAX
+  // Read in batches of TILEDB_UT_MAX_WRITE_COUNT
   size_t nbytes = 0;
   char *pbuf = reinterpret_cast<char *>(buffer);
   do {
-    ssize_t bytes_read = pread(fd, reinterpret_cast<void *>(pbuf), (length - nbytes) > SSIZE_MAX?SSIZE_MAX : length-nbytes, offset + nbytes);
+    ssize_t bytes_read = pread(fd, reinterpret_cast<void *>(pbuf), (length - nbytes) > TILEDB_UT_MAX_WRITE_COUNT?TILEDB_UT_MAX_WRITE_COUNT : length-nbytes, offset + nbytes);
     if (bytes_read < 0) {
       POSIX_ERROR("Cannot read from file; File reading error", filename);
       return TILEDB_FS_ERR;
@@ -393,11 +393,13 @@ int PosixFS::write_to_file(const std::string& filename, const void *buffer, size
     return TILEDB_FS_ERR;
   }
 
-  // Write in batches of SSIZE_MAX
+  // Write in batches of TILEDB_UT_MAX_WRITE_COUNT
   size_t nbytes = 0;
   char *pbuf = reinterpret_cast<char *>(const_cast<void *>(buffer));
   do {
-    ssize_t bytes_written = write(fd, reinterpret_cast<void *>(pbuf), (buffer_size - nbytes) > SSIZE_MAX ? SSIZE_MAX : buffer_size - nbytes);
+    size_t count = (buffer_size - nbytes) > TILEDB_UT_MAX_WRITE_COUNT ? TILEDB_UT_MAX_WRITE_COUNT : buffer_size - nbytes;
+    assert(count != 0);
+    ssize_t bytes_written = write(fd, reinterpret_cast<void *>(pbuf), count);
     if(bytes_written < 0) {
       POSIX_ERROR("Cannot write to file; File writing error", filename);
       return TILEDB_FS_ERR;

--- a/examples/src/tiledb_array_read_sparse_1.cc
+++ b/examples/src/tiledb_array_read_sparse_1.cc
@@ -32,6 +32,7 @@
 
 #include "tiledb.h"
 #include <cstdio>
+#include <inttypes.h>
 
 int main(int argc, char *argv[]) {
   // Initialize context with home dir if specified in command line, else
@@ -81,7 +82,7 @@ int main(int argc, char *argv[]) {
   printf("coords\t a1\t   a2\t     (a3.first, a3.second)\n");
   printf("--------------------------------------------------\n");
   for(int i=0; i<result_num; ++i) { 
-    printf("(%lld, %lld)", buffer_coords[2*i], buffer_coords[2*i+1]);
+    printf("(%" PRId64 ", %" PRId64 ")", buffer_coords[2*i], buffer_coords[2*i+1]);
     printf("\t %3d", buffer_a1[i]);
     size_t var_size = (i != result_num-1) ? buffer_a2[i+1] - buffer_a2[i] 
                                           : buffer_sizes[2] - buffer_a2[i];

--- a/test/src/c_api/test_array_schema_api.cc
+++ b/test/src/c_api/test_array_schema_api.cc
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/src/c_api/test_dense_array_api.cc
+++ b/test/src/c_api/test_dense_array_api.cc
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -72,8 +73,6 @@ DenseArrayTestFixture::~DenseArrayTestFixture() {
   rc = system(command.c_str());
   CHECK_RC(rc, 0);
 }
-
-
 
 
 /* ****************************** */
@@ -584,6 +583,8 @@ TEST_CASE_METHOD(DenseArrayTestFixture, "Test Dense Array - 10 random 2D arrays"
  * Tests random 2D subarray writes. 
  */
 TEST_CASE_METHOD(DenseArrayTestFixture, "Test random 2D subarray writes", "[test_random_dense_sorted_writes]") {
+  putenv("TILEDB_DISABLE_FILE_LOCKING=True");
+
   // Error code
   int rc;
 

--- a/test/src/storage_manager/test_posixfs.cc
+++ b/test/src/storage_manager/test_posixfs.cc
@@ -189,8 +189,8 @@ TEST_CASE_METHOD(PosixFSTestFixture, "Test PosixFS parallel operations", "[paral
   REQUIRE(fs.create_dir(test_dir) == TILEDB_FS_OK);
 
   bool complete = true;
-  auto iterations = std::thread::hardware_concurrency();
-  for (auto i=0; i<iterations; i++) {
+  uint iterations = std::thread::hardware_concurrency();
+  for (uint i=0; i<iterations; i++) {
     std::string filename = test_dir+"/foo"+std::to_string(i);
 
     for (auto j=0; j<2; j++) {
@@ -211,7 +211,7 @@ TEST_CASE_METHOD(PosixFSTestFixture, "Test PosixFS parallel operations", "[paral
   CHECK(fs.is_dir(test_dir+"new"));
 
   if (complete) {
-    for (auto i=0; i<iterations; i++) {
+    for (uint i=0; i<iterations; i++) {
       std::string filename = test_dir+"new/foo"+std::to_string(i);
       CHECK(fs.is_file(filename));
       CHECK(fs.file_size(filename) == ((size_t)TILEDB_UT_MAX_WRITE_COUNT)*2);

--- a/test/src/storage_manager/test_posixfs.cc
+++ b/test/src/storage_manager/test_posixfs.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#include <cctype>
 #include <cstdio>
 #include <string>
 #include <thread>
@@ -48,6 +49,10 @@ class PosixFSTestFixture {
  protected:
   PosixFS fs;
   std::string test_dir = "test_posixfs_dir";
+
+  PosixFSTestFixture() {
+    CHECK(fs.locking_support());
+  }
 
   ~PosixFSTestFixture() {
     // Remove the temporary dir
@@ -219,4 +224,28 @@ TEST_CASE_METHOD(PosixFSTestFixture, "Test PosixFS parallel operations", "[paral
   }
 
   CHECK_RC(fs.delete_dir(test_dir+"new"), TILEDB_FS_OK);
+}
+
+void test_locking_support(const std::string& disable_file_locking_value) {
+  std::cerr << disable_file_locking_value << std::endl;
+  std::string disable_file_locking_env = "TILEDB_DISABLE_FILE_LOCKING="+disable_file_locking_value;
+  CHECK(putenv(const_cast<char *>(disable_file_locking_env.c_str())) == 0);
+  const char *value = disable_file_locking_value.c_str();
+  if (strcasecmp(value, "true") == 0 || strcmp(value, "1") == 0) {
+    CHECK(!(new PosixFS())->locking_support());
+  } else {
+    CHECK((new PosixFS())->locking_support());
+  }
+}
+
+TEST_CASE("Test locking support", "[locking_support]") {
+  test_locking_support("True");
+  test_locking_support("true");
+  test_locking_support("TRUE");
+  test_locking_support("1");
+  test_locking_support("0");
+  test_locking_support("False");
+  test_locking_support("false");
+  test_locking_support("FALSE");
+  test_locking_support("Gibberish");
 }


### PR DESCRIPTION
Add support for in-place fragments for disable_file_locking, minor cleanup and unit tests for disable_file_locking. Note that there will be no fsync errors reported if file_locking is disabled.