### PR TITLE
Minor cleanup of dl related code and handle gzip errors explicitly

### DIFF
--- a/core/include/codec/codec.h
+++ b/core/include/codec/codec.h
@@ -137,7 +137,11 @@ class Codec {
       if (version.empty()) {
         handle = dlopen((dl_path+prefix+name+suffix).c_str(), RTLD_GLOBAL|RTLD_NOW);
       } else {
+#ifdef __APPLE__
         handle = dlopen((dl_path+prefix+name+"."+version+suffix).c_str(), RTLD_GLOBAL|RTLD_NOW);
+#else
+        handle = dlopen((dl_path+prefix+name+suffix+"."+version).c_str(), RTLD_GLOBAL|RTLD_NOW);
+#endif
       }
       if (handle) {
         return handle;

--- a/core/include/codec/codec.h
+++ b/core/include/codec/codec.h
@@ -113,6 +113,10 @@ class Codec {
     dl_error_ = dlerror();
   }
 
+  std::string& get_dlerror() {
+    return dl_error_;
+  }
+
  void *get_dlopen_handle(const std::string& name) {
     return get_dlopen_handle(name, "");
   }
@@ -130,14 +134,18 @@ class Codec {
     
     for (std::string dl_path : dl_paths_) {
       clear_dlerror();
-      handle = dlopen((dl_path+prefix+name+suffix).c_str(), RTLD_GLOBAL|RTLD_NOW);
+      if (version.empty()) {
+        handle = dlopen((dl_path+prefix+name+suffix).c_str(), RTLD_GLOBAL|RTLD_NOW);
+      } else {
+        handle = dlopen((dl_path+prefix+name+"."+version+suffix).c_str(), RTLD_GLOBAL|RTLD_NOW);
+      }
       if (handle) {
         return handle;
       }
     }
 
     if (!handle) {
-      dl_error_ = std::string(dlerror());
+      set_dlerror();
     }
     return handle;
   }

--- a/core/src/misc/utils.cc
+++ b/core/src/misc/utils.cc
@@ -432,6 +432,34 @@ std::string get_mac_addr() {
 }
 #endif
 
+void gzip_handle_error(int rc, const std::string& message) {
+  // Just listing all Z errors here for completion sake.
+  // Note that deflate() and inflate() should not throw errors technically
+  // but deflateInit() and inflateInit() can.
+  switch (rc) {
+    case Z_ERRNO:
+      UTILS_SYSTEM_ERROR(message+": Z_ERRNO");
+      break;
+    case Z_STREAM_ERROR:
+      UTILS_ERROR(message+": Z_STREAM_ERROR");
+      break;
+    case Z_DATA_ERROR:
+      UTILS_ERROR(message+": Z_DATA_ERROR");
+      break;
+    case Z_MEM_ERROR:
+      UTILS_ERROR(message+": Z_MEM_ERROR");
+      break;
+    case Z_BUF_ERROR:
+      UTILS_ERROR(message+": Z_BUF_ERROR");
+      break;
+    case Z_VERSION_ERROR:
+      UTILS_ERROR(message+": Z_VERSION_ERROR");
+      break;
+    default:
+      UTILS_ERROR(message+": " + std::to_string(rc));
+  }
+}
+
 ssize_t gzip(
     unsigned char* in, 
     size_t in_size,
@@ -449,7 +477,7 @@ ssize_t gzip(
   ret = deflateInit(&strm, level);
 
   if(ret != Z_OK) {
-    UTILS_ERROR("Cannot compress with GZIP");
+    gzip_handle_error(ret, "Cannot compress with GZIP: deflateInit error");
     (void)deflateEnd(&strm);
     return TILEDB_UT_ERR;
   }
@@ -466,7 +494,7 @@ ssize_t gzip(
 
   // Return 
   if(ret == Z_STREAM_ERROR || strm.avail_in != 0) {
-    UTILS_ERROR("Cannot compress with GZIP");
+    UTILS_ERROR("Cannot compress with GZIP: deflate error");
     return TILEDB_UT_ERR;
   } else {
     // Return size of compressed data
@@ -492,7 +520,7 @@ int gunzip(
   ret = inflateInit(&strm);
 
   if(ret != Z_OK) {
-    UTILS_ERROR("Cannot decompress with GZIP");
+    gzip_handle_error(ret, "Cannot decompress with GZIP: inflateInit error");
     return TILEDB_UT_ERR;
   }
 
@@ -504,7 +532,7 @@ int gunzip(
   ret = inflate(&strm, Z_FINISH);
 
   if(ret != Z_STREAM_END) {
-    UTILS_ERROR("Cannot decompress with GZIP");
+    gzip_handle_error(ret, "Cannot decompress with GZIP: inflate error");
     return TILEDB_UT_ERR;
   }
 
@@ -916,10 +944,11 @@ int read_from_file_after_decompression(StorageFS *fs, const std::string& filenam
   strm.opaque = Z_NULL;
   strm.avail_in = 0;
   strm.next_in = Z_NULL;
-    
-  if (inflateInit2(&strm, (windowBits + 32)) != Z_OK) {
+
+  int rc;
+  if ((rc = inflateInit2(&strm, (windowBits + 32))) != Z_OK) {
     free(in);
-    UTILS_PATH_ERROR("Could not inflate file", filename);
+    gzip_handle_error(rc, std::string("Could not initialize decompression for file ")+filename);
     return TILEDB_UT_ERR;
   }
 
@@ -930,7 +959,6 @@ int read_from_file_after_decompression(StorageFS *fs, const std::string& filenam
   buffer_size = 0;
     
   /* run inflate() on input until output buffer not full */
-  int rc;
   unsigned have;
   do {
     strm.avail_out = TILEDB_GZIP_CHUNK_SIZE;
@@ -941,10 +969,12 @@ int read_from_file_after_decompression(StorageFS *fs, const std::string& filenam
       case Z_NEED_DICT:
         rc = Z_DATA_ERROR;     /* and fall through */
       case Z_DATA_ERROR:
+      case Z_STREAM_ERROR:
       case Z_MEM_ERROR:
         free(in);
         inflateEnd(&strm);
-        UTILS_PATH_ERROR("Error encountered during inflate", filename);
+        close_file(fs, filename);
+        gzip_handle_error(rc, std::string("Error encountered during inflate with ")+filename);
         return TILEDB_UT_ERR;
     }
 
@@ -958,10 +988,9 @@ int read_from_file_after_decompression(StorageFS *fs, const std::string& filenam
   /* clean up and return */
   free(in);
   inflateEnd(&strm);
-
-  assert(rc == Z_STREAM_END); // All bytes have been decompressed
-
   close_file(fs, filename);
+  
+  assert(rc == Z_STREAM_END); // All bytes have been decompressed
   
   return TILEDB_UT_OK;
 }
@@ -1593,8 +1622,8 @@ int write_to_file_after_compression(StorageFS *fs, const std::string& filename, 
   strm.zfree = Z_NULL;
   strm.opaque = Z_NULL;
 
-  if (deflateInit2 (&strm, TILEDB_COMPRESSION_LEVEL_GZIP, Z_DEFLATED, windowBits | GZIP_ENCODING, 8, Z_DEFAULT_STRATEGY) != Z_OK) {
-    UTILS_PATH_ERROR("Could not initialize for gzip compression", filename);
+  if ((rc = deflateInit2 (&strm, TILEDB_COMPRESSION_LEVEL_GZIP, Z_DEFLATED, windowBits | GZIP_ENCODING, 8, Z_DEFAULT_STRATEGY)) != Z_OK) {
+    gzip_handle_error(rc, std::string("Could not initialize compression for ")+filename);
     return TILEDB_UT_ERR;
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,7 +45,7 @@ foreach(TILEDB_TEST_SOURCE ${TILEDB_TEST_SOURCES})
   string(REGEX REPLACE ".cc$" "" TARGET ${FILENAME})
   
   add_executable(${TARGET} EXCLUDE_FROM_ALL ${TILEDB_TEST_SOURCE})
-  target_link_libraries(${TARGET} tiledb_static ${TILEDB_LIB_DEPENDENCIES})
+  target_link_libraries(${TARGET} tiledb_static ${TILEDB_LIB_DEPENDENCIES} -ldl)
 
   add_test(${TARGET} ${TARGET})
   set(ALL_CMDS ${ALL_CMDS} ${TARGET})

--- a/test/src/codec/test_codec.cc
+++ b/test/src/codec/test_codec.cc
@@ -1,0 +1,103 @@
+/**
+ * @file   test_codec.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * @section DESCRIPTION
+ *
+ * Test compression/decompression tiledb classes
+ */
+
+#include "catch.h"
+#include "codec.h"
+#include "codec_gzip.h"
+#include "tiledb.h"
+
+#include <limits.h>
+
+class TestCodecBasic : public Codec {
+ public:
+  using Codec::Codec;
+  int compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
+    return TILEDB_CD_OK;
+  }
+  int decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
+    return TILEDB_CD_OK;
+  }
+};
+
+TEST_CASE("Test codec static methods", "[codec_static]") {
+  CHECK(Codec::get_default_level(TILEDB_GZIP) == TILEDB_COMPRESSION_LEVEL_GZIP);
+  CHECK(Codec::get_default_level(INT_MAX) == -1);
+}
+
+TEST_CASE("Test codec basic", "[codec_basic]") {
+  TestCodecBasic *codec_basic = new TestCodecBasic(0);
+  
+  void *dl_handle = codec_basic->get_dlopen_handle("non-existent-library");
+  CHECK(dl_handle == NULL);
+  CHECK(!codec_basic->get_dlerror().empty());
+
+  dl_handle = codec_basic->get_dlopen_handle("non-existent-library", "5.2");
+  CHECK(dl_handle == NULL);
+  CHECK(!codec_basic->get_dlerror().empty());
+  
+  dl_handle = codec_basic->get_dlopen_handle("z");
+  CHECK(dl_handle);
+  CHECK(codec_basic->get_dlerror().empty());
+
+  dl_handle = codec_basic->get_dlopen_handle("z", "1");
+  CHECK(dl_handle);
+  CHECK(codec_basic->get_dlerror().empty());
+  
+  dl_handle = codec_basic->get_dlopen_handle("z", "non-existent-version");
+  CHECK(dl_handle == NULL);
+  CHECK(!codec_basic->get_dlerror().empty());
+
+  free(codec_basic);
+}
+
+TEST_CASE("Test zlib", "[codec-z]") {
+  Codec* zlib = new CodecGzip(TILEDB_COMPRESSION_LEVEL_GZIP);
+  unsigned char test_string[] = "HELLO";
+  unsigned char* buffer;
+  size_t buffer_size;
+
+  CHECK(zlib->compress_tile(test_string, 0, (void **)(&buffer), buffer_size) == TILEDB_CD_OK);
+  CHECK(zlib->compress_tile(test_string, 6, (void **)(&buffer), buffer_size) == TILEDB_CD_OK);
+
+  unsigned char* decompressed_string =  (unsigned char*)malloc(6);
+  CHECK(zlib->decompress_tile(buffer, buffer_size, decompressed_string, 6) == TILEDB_CD_OK);
+
+  // Should get Z_BUF_ERROR
+  CHECK(zlib->decompress_tile(buffer, buffer_size, decompressed_string, 4) == TILEDB_CD_ERR);
+  CHECK(zlib->decompress_tile(buffer, 4, decompressed_string, 6) == TILEDB_CD_ERR);
+  // Should get Z_DATA_ERROR
+  CHECK(zlib->decompress_tile(test_string, 4, decompressed_string, 6) == TILEDB_CD_ERR);
+   
+  free(zlib);
+}
+
+


### PR DESCRIPTION
Allowing for gzip errors to be handled explicitly to allow for more logging in case of gzip errors.
Check this [gatk forum issue](https://gatkforums.broadinstitute.org/gatk/discussion/24457/tiledb-gzip-error-when-using-genotypegvcfs-on-genomicsdb) where it looks like the GenomicDB/TileDB artifacts were corrupted somehow on a lustre filesystem. The only error was "Cannot decompress with GZIP".

Also, libraries can now be specified by their name and version while getting loaded dynamically in addition to just by name.