### PR TITLE
Add unit tests for tiledb_utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
         brew install cmake lcov mpich ;
         brew install openssl ossp-uuid;
         export OPENSSL_ROOT_DIR=/usr/local/opt/openssl;
+        export PATH=$PATH:/usr/local/bin
       else
         echo "Platform $TRAVIS_OS_NAME not yet supported";
         exit 1;
@@ -66,6 +67,11 @@ install:
     - make -j 4
 
 before_script:
+    - if [[ $TRAVIS_OS_NAME == osx ]]; then
+        echo "Nalini - Locating lcov";
+        ls -l /usr/local/bin/*;
+        ls -l /usr/local/Cellar/*
+      fi
     - lcov --directory $TILEDB_BUILD_DIR --zerocounters
 
 script:
@@ -79,8 +85,8 @@ after_success:
     - cd $TILEDB_BUILD_DIR
     - find deps -name *.gcda -type f -delete
     - if [[ $TRAVIS_OS_NAME == osx ]]; then
-        echo "Nalini - Locating lcov"
-        ls -l /usr/local/bin/*
+        echo "Nalini - Locating lcov";
+        ls -l /usr/local/bin/*;
         ls -l /usr/local/Cellar/*
       fi
     - if [[ $DEBUG_LCOV == true ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_script:
 
 script:
     - if [[ $INSTALL_TYPE != basic ]]; then
-        $TRAVIS_BUILD_DIR/.travis/scripts/run_dfs_tests.sh;
+        make check && $TRAVIS_BUILD_DIR/.travis/scripts/run_dfs_tests.sh;
       else
         make tests -j 4;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,8 @@ before_script:
 
 script:
     - if [[ $INSTALL_TYPE != basic ]]; then
-        make check && $TRAVIS_BUILD_DIR/.travis/scripts/run_dfs_tests.sh;
+        make check;
+        $TRAVIS_BUILD_DIR/.travis/scripts/run_dfs_tests.sh;
       else
         make tests -j 4;
 fi:wq

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,6 @@ before_script:
 
 script:
     - if [[ $INSTALL_TYPE != basic ]]; then
-        make check;
         $TRAVIS_BUILD_DIR/.travis/scripts/run_dfs_tests.sh;
       else
         make tests -j 4;

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,10 @@ before_script:
 
 script:
     - if [[ $INSTALL_TYPE != basic ]]; then
-        $TRAVIS_BUILD_DIR/.travis/scripts/run_dfs_tests.sh;
+        make check && $TRAVIS_BUILD_DIR/.travis/scripts/run_dfs_tests.sh;
       else
         make tests -j 4;
-fi:wq
+fi
 
 after_success:
     - cd $TILEDB_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
         brew install cmake lcov mpich ;
         brew install openssl ossp-uuid;
         export OPENSSL_ROOT_DIR=/usr/local/opt/openssl;
-        export PATH=$PATH:/usr/local/bin
+        export PATH=$PATH:/usr/local/bin;
       else
         echo "Platform $TRAVIS_OS_NAME not yet supported";
         exit 1;
@@ -67,11 +67,6 @@ install:
     - make -j 4
 
 before_script:
-    - if [[ $TRAVIS_OS_NAME == osx ]]; then
-        echo "Nalini - Locating lcov";
-        ls -l /usr/local/bin/;
-        ls -l /usr/local/Cellar/;
-      fi
     - lcov --directory $TILEDB_BUILD_DIR --zerocounters
 
 script:
@@ -84,11 +79,6 @@ script:
 after_success:
     - cd $TILEDB_BUILD_DIR
     - find deps -name *.gcda -type f -delete
-    - if [[ $TRAVIS_OS_NAME == osx ]]; then
-        echo "Nalini - Locating lcov";
-        ls -l /usr/local/bin/*;
-        ls -l /usr/local/Cellar/*
-      fi
     - if [[ $DEBUG_LCOV == true ]]; then
         lcov --directory core --capture --output-file coverage.info;
         lcov --remove coverage.info '/opt*' '*/usr/*' -o coverage.info;

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,11 @@ script:
 after_success:
     - cd $TILEDB_BUILD_DIR
     - find deps -name *.gcda -type f -delete
+    - if [[ $TRAVIS_OS_NAME == osx ]]; then
+        echo "Nalini - Locating lcov"
+        ls -l /usr/local/bin/*
+        ls -l /usr/local/Cellar/*
+      fi
     - if [[ $DEBUG_LCOV == true ]]; then
         lcov --directory core --capture --output-file coverage.info;
         lcov --remove coverage.info '/opt*' '*/usr/*' -o coverage.info;

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,13 @@ install:
         sudo apt-get -y install cmake lcov mpich;
         sudo apt-get -y install zlib1g-dev libssl-dev uuid-dev;
       elif [[ $TRAVIS_OS_NAME == osx ]]; then
-        brew install cmake lcov mpich ;
+        brew install cmake mpich;
+        echo "Installing lcov";
+        brew install -v lcov;
+        echo "Installing lcov DONE";
+        echo "Finding lcov";
+        find /usr/local -name lcov -print;
+        echo "Findong lcov DONE";
         brew install openssl ossp-uuid;
         export OPENSSL_ROOT_DIR=/usr/local/opt/openssl;
         export PATH=$PATH:/usr/local/bin;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,7 @@ install:
         sudo apt-get -y install zlib1g-dev libssl-dev uuid-dev;
       elif [[ $TRAVIS_OS_NAME == osx ]]; then
         brew install cmake mpich;
-        echo "Installing lcov";
-        brew install -v lcov;
-        echo "Installing lcov DONE";
-        echo "Finding lcov";
-        find /usr/local -name lcov -print;
-        echo "Findong lcov DONE";
+        brew install lcov;
         brew install openssl ossp-uuid;
         export OPENSSL_ROOT_DIR=/usr/local/opt/openssl;
         export PATH=$PATH:/usr/local/bin;

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,8 @@ install:
 before_script:
     - if [[ $TRAVIS_OS_NAME == osx ]]; then
         echo "Nalini - Locating lcov";
-        ls -l /usr/local/bin/*;
-        ls -l /usr/local/Cellar/*
+        ls -l /usr/local/bin/;
+        ls -l /usr/local/Cellar/;
       fi
     - lcov --directory $TILEDB_BUILD_DIR --zerocounters
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,10 @@ before_script:
 
 script:
     - if [[ $INSTALL_TYPE != basic ]]; then
-        $TRAVIS_BUILD_DIR/.travis/scripts/run_dfs_tests.sh;
+        make check && $TRAVIS_BUILD_DIR/.travis/scripts/run_dfs_tests.sh;
       else
         make tests -j 4;
-      fi
+fi:wq
 
 after_success:
     - cd $TILEDB_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,10 @@ before_script:
 
 script:
     - if [[ $INSTALL_TYPE != basic ]]; then
-        make check && $TRAVIS_BUILD_DIR/.travis/scripts/run_dfs_tests.sh;
+        $TRAVIS_BUILD_DIR/.travis/scripts/run_dfs_tests.sh;
       else
         make tests -j 4;
-fi
+      fi
 
 after_success:
     - cd $TILEDB_BUILD_DIR

--- a/.travis/scripts/run_dfs_tests.sh
+++ b/.travis/scripts/run_dfs_tests.sh
@@ -14,8 +14,9 @@ if [[ $INSTALL_TYPE != basic ]]; then
     tiledb_utils_tests "hdfs://localhost:9000/travis_unit_test" &&
 		time $TRAVIS_BUILD_DIR/examples/run_examples.sh "hdfs://localhost:9000/travis_test" 
 	elif [[ $INSTALL_TYPE == gcs ]]; then
+    export GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/.travis/resources/gcs/GCS.json
     tiledb_utils_tests "gs://$GS_BUCKET/travis_unit_test" &&
-		time GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/.travis/resources/gcs/GCS.json $TRAVIS_BUILD_DIR/examples/run_examples.sh "gs://$GS_BUCKET/travis_test"
+		time $TRAVIS_BUILD_DIR/examples/run_examples.sh "gs://$GS_BUCKET/travis_test"
 	elif [[ $INSTALL_TYPE == azure ]]; then
     tiledb_utils_tests "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_unit_test" &&
 		time $TRAVIS_BUILD_DIR/examples/run_examples.sh "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_test"

--- a/.travis/scripts/run_dfs_tests.sh
+++ b/.travis/scripts/run_dfs_tests.sh
@@ -3,13 +3,13 @@
 if [[ $INSTALL_TYPE != basic ]]; then
 	cd $TILEDB_BUILD_DIR && make examples && cd examples
 	if [[ $INSTALL_TYPE == hdfs ]]; then
-    $TILEDB_BUILD_DIR/test/test_tiledb_utils "hdfs://localhost:9000/travis_unit_test" && 
+    $TILEDB_BUILD_DIR/test/test_tiledb_utils --test-dir "hdfs://localhost:9000/travis_unit_test" && 
 		time $TRAVIS_BUILD_DIR/examples/run_examples.sh "hdfs://localhost:9000/travis_test" 
 	elif [[ $INSTALL_TYPE == gcs ]]; then
-    $TILEDB_BUILD_DIR/test/test_tiledb_utils "gs://$GS_BUCKET/travis_unit_test" &&
+    $TILEDB_BUILD_DIR/test/test_tiledb_utils --test-dir "gs://$GS_BUCKET/travis_unit_test" &&
 		time GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/.travis/resources/gcs/GCS.json $TRAVIS_BUILD_DIR/examples/run_examples.sh "gs://$GS_BUCKET/travis_test"
 	elif [[ $INSTALL_TYPE == azure ]]; then
-    $TILEDB_BUILD_DIR/test/test_tiledb_utils "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_unit_test" &&
+    $TILEDB_BUILD_DIR/test/test_tiledb_utils --test-dir "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_unit_test" &&
 		time $TRAVIS_BUILD_DIR/examples/run_examples.sh "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_test"
 	fi
 	if [[ ! $! -eq 0 ]]; then

--- a/.travis/scripts/run_dfs_tests.sh
+++ b/.travis/scripts/run_dfs_tests.sh
@@ -3,10 +3,13 @@
 if [[ $INSTALL_TYPE != basic ]]; then
 	cd $TILEDB_BUILD_DIR && make examples && cd examples
 	if [[ $INSTALL_TYPE == hdfs ]]; then
-		time $TRAVIS_BUILD_DIR/examples/run_examples.sh "hdfs://localhost:9000/travis_test"
+    $TILEDB_BUILD_DIR/test/test_tiledb_utils.h "hdfs://localhost:9000/travis_unit_test" && 
+		time $TRAVIS_BUILD_DIR/examples/run_examples.sh "hdfs://localhost:9000/travis_test" 
 	elif [[ $INSTALL_TYPE == gcs ]]; then
+    $TILEDB_BUILD_DIR/test/test_tiledb_utils.h "gs://$GS_BUCKET/travis_unit_test" &&
 		time GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/.travis/resources/gcs/GCS.json $TRAVIS_BUILD_DIR/examples/run_examples.sh "gs://$GS_BUCKET/travis_test"
 	elif [[ $INSTALL_TYPE == azure ]]; then
+    $TILEDB_BUILD_DIR/test/test_tiledb_utils.h "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_unit_test" &&
 		time $TRAVIS_BUILD_DIR/examples/run_examples.sh "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_test"
 	fi
 	if [[ ! $! -eq 0 ]]; then

--- a/.travis/scripts/run_dfs_tests.sh
+++ b/.travis/scripts/run_dfs_tests.sh
@@ -6,6 +6,7 @@ tiledb_utils_tests() {
   $TILEDB_BUILD_DIR/test/test_tiledb_utils [array_exists] --test-dir $1 &&
   $TILEDB_BUILD_DIR/test/test_tiledb_utils [get_fragment_names] --test-dir $1 &&
   $TILEDB_BUILD_DIR/test/test_tiledb_utils [file_ops] --test-dir $1
+	$TILEDB_BUILD_DIR/test/test_tiledb_utils [move_across_filesystems] --test-dir $1
 }
 
 if [[ $INSTALL_TYPE != basic ]]; then

--- a/.travis/scripts/run_dfs_tests.sh
+++ b/.travis/scripts/run_dfs_tests.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 tiledb_utils_tests() {
-  echo "tiledb_utils_tests: $TILEDB_BUILD_DIR/test/test_tiledb_utils [initialize-workspace] --test-dir $1"
-	$TILEDB_BUILD_DIR/test/test_tiledb_utils [initialize-workspace] --test-dir $1 && 
-  $TILEDB_BUILD_DIR/test/test_tiledb_utils [create-workspace] --test-dir $1
+	$TILEDB_BUILD_DIR/test/test_tiledb_utils [initialize_workspace] --test-dir $1 && 
+  $TILEDB_BUILD_DIR/test/test_tiledb_utils [create_workspace] --test-dir $1 &&
+  $TILEDB_BUILD_DIR/test/test_tiledb_utils [array_exists] --test-dir $1 &&
+  $TILEDB_BUILD_DIR/test/test_tiledb_utils [get_fragment_names] --test-dir $1 &&
+  $TILEDB_BUILD_DIR/test/test_tiledb_utils [file_ops] --test-dir $1
 }
 
 if [[ $INSTALL_TYPE != basic ]]; then

--- a/.travis/scripts/run_dfs_tests.sh
+++ b/.travis/scripts/run_dfs_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 tiledb_utils_tests() {
+  echo "tiledb_utils_tests: $TILEDB_BUILD_DIR/test/test_tiledb_utils [initialize-workspace] --test-dir $1"
 	$TILEDB_BUILD_DIR/test/test_tiledb_utils [initialize-workspace] --test-dir $1 && 
   $TILEDB_BUILD_DIR/test/test_tiledb_utils [create-workspace] --test-dir $1
 }

--- a/.travis/scripts/run_dfs_tests.sh
+++ b/.travis/scripts/run_dfs_tests.sh
@@ -3,13 +3,13 @@
 if [[ $INSTALL_TYPE != basic ]]; then
 	cd $TILEDB_BUILD_DIR && make examples && cd examples
 	if [[ $INSTALL_TYPE == hdfs ]]; then
-    $TILEDB_BUILD_DIR/test/test_tiledb_utils.h "hdfs://localhost:9000/travis_unit_test" && 
+    $TILEDB_BUILD_DIR/test/test_tiledb_utils "hdfs://localhost:9000/travis_unit_test" && 
 		time $TRAVIS_BUILD_DIR/examples/run_examples.sh "hdfs://localhost:9000/travis_test" 
 	elif [[ $INSTALL_TYPE == gcs ]]; then
-    $TILEDB_BUILD_DIR/test/test_tiledb_utils.h "gs://$GS_BUCKET/travis_unit_test" &&
+    $TILEDB_BUILD_DIR/test/test_tiledb_utils "gs://$GS_BUCKET/travis_unit_test" &&
 		time GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/.travis/resources/gcs/GCS.json $TRAVIS_BUILD_DIR/examples/run_examples.sh "gs://$GS_BUCKET/travis_test"
 	elif [[ $INSTALL_TYPE == azure ]]; then
-    $TILEDB_BUILD_DIR/test/test_tiledb_utils.h "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_unit_test" &&
+    $TILEDB_BUILD_DIR/test/test_tiledb_utils "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_unit_test" &&
 		time $TRAVIS_BUILD_DIR/examples/run_examples.sh "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_test"
 	fi
 	if [[ ! $! -eq 0 ]]; then

--- a/.travis/scripts/run_dfs_tests.sh
+++ b/.travis/scripts/run_dfs_tests.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
+tiledb_utils_tests() {
+	$TILEDB_BUILD_DIR/test/test_tiledb_utils [initialize-workspace] --test-dir $1 && 
+  $TILEDB_BUILD_DIR/test/test_tiledb_utils [create-workspace] --test-dir $1
+}
+
 if [[ $INSTALL_TYPE != basic ]]; then
 	cd $TILEDB_BUILD_DIR && make examples && cd examples
 	if [[ $INSTALL_TYPE == hdfs ]]; then
-    $TILEDB_BUILD_DIR/test/test_tiledb_utils --test-dir "hdfs://localhost:9000/travis_unit_test" && 
+    tiledb_utils_tests "hdfs://localhost:9000/travis_unit_test" &&
 		time $TRAVIS_BUILD_DIR/examples/run_examples.sh "hdfs://localhost:9000/travis_test" 
 	elif [[ $INSTALL_TYPE == gcs ]]; then
-    $TILEDB_BUILD_DIR/test/test_tiledb_utils --test-dir "gs://$GS_BUCKET/travis_unit_test" &&
+    tiledb_utils_tests "gs://$GS_BUCKET/travis_unit_test" &&
 		time GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/.travis/resources/gcs/GCS.json $TRAVIS_BUILD_DIR/examples/run_examples.sh "gs://$GS_BUCKET/travis_test"
 	elif [[ $INSTALL_TYPE == azure ]]; then
-    $TILEDB_BUILD_DIR/test/test_tiledb_utils --test-dir "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_unit_test" &&
+    tiledb_utils_tests "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_unit_test" &&
 		time $TRAVIS_BUILD_DIR/examples/run_examples.sh "wasbs://$AZURE_CONTAINER_NAME@$AZURE_ACCOUNT_NAME.blob.core.windows.net/travis_test"
 	fi
 	if [[ ! $! -eq 0 ]]; then

--- a/core/include/c_api/tiledb_storage.h
+++ b/core/include/c_api/tiledb_storage.h
@@ -158,6 +158,8 @@ std::vector<std::string> get_files(const TileDB_CTX* tiledb_ctx, const std::stri
  */
 size_t file_size(const TileDB_CTX* tiledb_ctx, const std::string& file);
 
+int create_file(const TileDB_CTX* tiledb_ctx, const std::string& filename, int flags, mode_t mode);
+
 /**
  * Reads data from a file into a buffer.
  *

--- a/core/include/c_api/tiledb_utils.h
+++ b/core/include/c_api/tiledb_utils.h
@@ -54,6 +54,14 @@ std::vector<std::string> get_array_names(const std::string& workspace);
 
 std::vector<std::string> get_fragment_names(const std::string& workspace);
 
+bool is_dir(const std::string& dirpath);
+
+int create_dir(const std::string& dirpath);
+
+int delete_dir(const std::string& dirpath);
+
+bool is_file(const std::string& filepath);
+
 /**
  * buffer is malloc'ed and has to be freed by calling function
  */

--- a/core/include/c_api/tiledb_utils.h
+++ b/core/include/c_api/tiledb_utils.h
@@ -42,10 +42,9 @@ namespace TileDBUtils {
 
 bool is_cloud_path(const std::string& path);
 
-int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool overwrite,
-    const bool disable_file_locking=false);
+int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool overwrite=false, const bool disable_file_locking=false);
 
-int create_workspace(const std::string &workspace, bool replace);
+int create_workspace(const std::string &workspace, bool replace=false);
 
 bool workspace_exists(const std::string& workspace);
 
@@ -62,7 +61,7 @@ int read_entire_file(const std::string& filename, void **buffer, size_t *length)
 
 int read_file(const std::string& filename, off_t offset, void *buffer, size_t length);
 
-int write_file(const std::string& filename, const void *buffer, size_t length, const bool overwrite);
+int write_file(const std::string& filename, const void *buffer, size_t length, const bool overwrite=false);
 
 int delete_file(const std::string& filename);
 

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -1846,14 +1846,14 @@ int delete_dir(const TileDB_CTX* tiledb_ctx, const std::string& dir) {
 }
 
 std::vector<std::string> get_dirs(const TileDB_CTX* tiledb_ctx, const std::string& dir) {
-  if (sanity_check_fs(tiledb_ctx)) {;
+  if (sanity_check_fs(tiledb_ctx)) {
     return get_dirs(tiledb_ctx->storage_manager_->get_config()->get_filesystem(), dir);
   }
   return std::vector<std::string>{};
 }
  
 std::vector<std::string> get_files(const TileDB_CTX* tiledb_ctx, const std::string& dir) {
-  if (sanity_check_fs(tiledb_ctx)) {;
+  if (sanity_check_fs(tiledb_ctx)) {
     return get_files(tiledb_ctx->storage_manager_->get_config()->get_filesystem(), dir);
   }
   return std::vector<std::string>{};
@@ -1862,18 +1862,20 @@ std::vector<std::string> get_files(const TileDB_CTX* tiledb_ctx, const std::stri
 
 int read_file(const TileDB_CTX* tiledb_ctx, const std::string& filename, off_t offset, void *buffer, size_t length) {
   if (sanity_check_fs(tiledb_ctx)) {
-    if (!read_from_file(tiledb_ctx->storage_manager_->get_config()->get_filesystem(), filename, offset, buffer, length))
-       strcpy(tiledb_errmsg, tiledb_fs_errmsg.c_str());
-    return TILEDB_OK;
+    if (!read_from_file(tiledb_ctx->storage_manager_->get_config()->get_filesystem(), filename, offset, buffer, length)) {
+      return TILEDB_OK;
+    }
+    strcpy(tiledb_errmsg, tiledb_fs_errmsg.c_str());
   }
   return TILEDB_ERR;
 }
 
 int write_file(const TileDB_CTX* tiledb_ctx, const std::string& filename, const void *buffer, size_t buffer_size) {
   if (sanity_check(tiledb_ctx)) {
-    if (!write_to_file(tiledb_ctx->storage_manager_->get_config()->get_filesystem(), filename, buffer, buffer_size))
-      strcpy(tiledb_errmsg, tiledb_fs_errmsg.c_str()); 
-    return TILEDB_OK;
+    if (!write_to_file(tiledb_ctx->storage_manager_->get_config()->get_filesystem(), filename, buffer, buffer_size)) {
+      return TILEDB_OK;
+    }
+    strcpy(tiledb_errmsg, tiledb_fs_errmsg.c_str());
   }
   return TILEDB_ERR;
 }

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -1860,6 +1860,13 @@ std::vector<std::string> get_files(const TileDB_CTX* tiledb_ctx, const std::stri
 
 }
 
+int create_file(const TileDB_CTX* tiledb_ctx, const std::string& filename, int flags, mode_t mode) {
+    if (sanity_check_fs(tiledb_ctx)) {
+      return create_file(tiledb_ctx->storage_manager_->get_config()->get_filesystem(), filename, flags, mode);
+    }
+    return TILEDB_ERR;
+}
+
 int read_file(const TileDB_CTX* tiledb_ctx, const std::string& filename, off_t offset, void *buffer, size_t length) {
   if (sanity_check_fs(tiledb_ctx)) {
     if (!read_from_file(tiledb_ctx->storage_manager_->get_config()->get_filesystem(), filename, offset, buffer, length)) {

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -208,6 +208,50 @@ std::vector<std::string> get_fragment_names(const std::string& workspace)
   return fragment_names;
 }
 
+bool is_dir(const std::string& dirpath)
+{
+  TileDB_CTX *tiledb_ctx;
+  if (setup(&tiledb_ctx, parent_dir(dirpath))) {
+    return false;
+  }
+  bool check = is_dir(tiledb_ctx, dirpath);
+  finalize(tiledb_ctx);
+  return check;
+}
+
+int create_dir(const std::string& dirpath)
+{
+  TileDB_CTX *tiledb_ctx;
+  if (setup(&tiledb_ctx, parent_dir(dirpath))) {
+    return false;
+  }
+  int rc = create_dir(tiledb_ctx, dirpath);
+  finalize(tiledb_ctx);
+  return rc;
+}
+
+int delete_dir(const std::string& dirpath)
+{
+  TileDB_CTX *tiledb_ctx;
+  if (setup(&tiledb_ctx, parent_dir(dirpath))) {
+    return false;
+  }
+  int rc = delete_dir(tiledb_ctx, dirpath);
+  finalize(tiledb_ctx);
+  return rc;
+}
+
+bool is_file(const std::string& filepath)
+{
+  TileDB_CTX *tiledb_ctx;
+  if (setup(&tiledb_ctx, parent_dir(filepath))) {
+    return false;
+  }
+  bool check = is_file(tiledb_ctx, filepath);
+  finalize(tiledb_ctx);
+  return check;
+}
+
 static int check_file(TileDB_CTX *tiledb_ctx, std::string filename) {
   if (is_dir(tiledb_ctx, filename)) {
     finalize(tiledb_ctx);

--- a/core/src/storage_manager/storage_hdfs.cc
+++ b/core/src/storage_manager/storage_hdfs.cc
@@ -144,8 +144,8 @@ HDFS::HDFS(const std::string& home) {
     throw std::system_error(ECONNREFUSED, std::generic_category(), "Error getting hdfs connection");
   }
 
-  if (hdfsSetWorkingDirectory(hdfs_handle_, home.c_str())) {
-    PRINT_ERROR("Error setting up hdfs working directory");
+  if (hdfsSetWorkingDirectory(hdfs_handle_, ((path_url.path().empty())?(home+"/"):home).c_str())) {
+    PRINT_ERROR(std::string("Error setting up hdfs working directory ") + home);
     throw std::system_error(ENOENT, std::generic_category(), "Error setting up hdfs working directory");
   }
 

--- a/core/src/storage_manager/storage_posixfs.cc
+++ b/core/src/storage_manager/storage_posixfs.cc
@@ -40,6 +40,7 @@
 #include <cstdio>
 #include <dirent.h>
 #include <fcntl.h>
+#include <ftw.h>
 #include <iostream>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -181,47 +182,23 @@ int PosixFS::create_dir(const std::string& dir) {
   return TILEDB_FS_OK;
 }
 
+static int delete_file_nftw_cb(const char *filepath, const struct stat *ptr, int flag, struct FTW *ftwbuf) {
+  if (remove(filepath)) {
+    POSIX_ERROR("Could not remove file", filepath);
+    return TILEDB_FS_ERR;
+  }
+  return TILEDB_FS_OK;
+}
+
 int PosixFS::delete_dir(const std::string& dirname) {
   reset_errno();
-  
+
   // Get real path
   std::string dirname_real = this->real_dir(dirname); 
 
-  // Delete the contents of the directory
-  std::string filename; 
-  struct dirent *next_file;
-  DIR* dir = opendir(dirname_real.c_str());
-
-  if(dir == NULL) {
-    POSIX_ERROR("Cannot open directory", dirname);
+  if (nftw(dirname_real.c_str(), delete_file_nftw_cb, 64, FTW_DEPTH | FTW_PHYS)) {
+    POSIX_ERROR("Could not recursively delete directory", dirname);
     return TILEDB_FS_ERR;
-  }
-
-  std::vector<std::string> all_filenames;
-  while((next_file = readdir(dir))) {
-    if(!strcmp(next_file->d_name, ".") ||
-       !strcmp(next_file->d_name, ".."))
-      continue;
-    filename = dirname_real + "/" + next_file->d_name;
-    all_filenames.emplace_back(filename);
-  }
-
-  for(const auto& curr_filename : all_filenames) {
-    if(remove(curr_filename.c_str())) {
-      POSIX_ERROR("Cannot delete file", curr_filename);   
-      return TILEDB_FS_ERR;
-    }
-  } 
- 
-  // Close directory 
-  if(closedir(dir)) {
-    POSIX_ERROR("Cannot close directory", dirname);
-    return TILEDB_FS_ERR;
-  }
-
-  // Remove directory
-  if(rmdir(dirname.c_str())) {
-    POSIX_ERROR("Cannot delete directory", dirname);
   }
 
   // Success

--- a/test/src/c_api/test_tiledb_utils.cc
+++ b/test/src/c_api/test_tiledb_utils.cc
@@ -1,0 +1,223 @@
+/**
+ * @file   test_tiledb_utils.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * @section DESCRIPTION
+ *
+ * Unit Tests for tiledb_utils.cc 
+ */
+
+#include "catch.h"
+
+#include "storage_posixfs.h"
+#include "tiledb.h"
+#include "tiledb_utils.h"
+
+#include <string.h>
+#include <fcntl.h>
+
+const std::string& workspace("WORKSPACE");
+PosixFS posix_fs;
+
+class TempDir {
+ public:
+  TempDir() {
+    create_temp_directory();
+  }
+
+  ~TempDir() {
+    if (strlen(get_temp_dir()) != 0) {
+      posix_fs.delete_dir(get_temp_dir());
+    }
+  }
+
+  const char *get_temp_dir() {
+    return tmp_dirname_;
+  }
+
+ private:
+  char tmp_dir_[PATH_MAX];
+  char *tmp_dirname_;
+  
+  void create_temp_directory() {
+#ifdef TEST_HDFS
+#   error NYI: Port to run hdfs tests
+#else
+    const char *tmp_dir = getenv("TMPDIR");
+    if (tmp_dir == NULL) {
+      tmp_dir = P_tmpdir; // defined in stdio
+    }
+    assert(tmp_dir != NULL);
+    if (tmp_dir[strlen(tmp_dir)-1]=='/') {
+      snprintf(tmp_dir_, PATH_MAX, "%sTileDBTestXXXXXX", tmp_dir);
+    } else {
+      snprintf(tmp_dir_, PATH_MAX, "%s/TileDBTestXXXXXX", tmp_dir);
+    }
+    tmp_dirname_ = mkdtemp(tmp_dir_);
+    REQUIRE(tmp_dirname_ != NULL);
+#endif
+  }
+};
+
+TEST_CASE_METHOD(TempDir, "Test initialize_workspace", "[initialize_workspace]") {
+  std::string workspace_path = std::string(get_temp_dir())+"/"+workspace;
+
+  TileDB_CTX *tiledb_ctx;
+  CHECK(TileDBUtils::initialize_workspace(&tiledb_ctx, workspace_path, false) == 0); // OK
+  CHECK(TileDBUtils::workspace_exists(workspace_path));
+  CHECK(!tiledb_ctx_finalize(tiledb_ctx));
+
+  CHECK(TileDBUtils::initialize_workspace(&tiledb_ctx, workspace_path, false) == 1); // EXISTS
+  CHECK(!tiledb_ctx_finalize(tiledb_ctx));
+
+  CHECK(TileDBUtils::initialize_workspace(&tiledb_ctx, workspace_path, true) == 0); // OK
+  CHECK(!tiledb_ctx_finalize(tiledb_ctx));
+
+  CHECK(!posix_fs.delete_dir(workspace_path));
+  CHECK(!posix_fs.create_file(workspace_path, O_WRONLY | O_CREAT | O_SYNC, S_IRWXU));
+
+  CHECK(TileDBUtils::initialize_workspace(&tiledb_ctx, workspace_path, true) == -1); // NOT_DIR
+  CHECK(!tiledb_ctx_finalize(tiledb_ctx));
+  
+  CHECK(TileDBUtils::initialize_workspace(&tiledb_ctx, workspace_path) == -1); // NOT_DIR
+  CHECK(!tiledb_ctx_finalize(tiledb_ctx));
+}
+
+TEST_CASE_METHOD(TempDir, "Test create_workspace", "[create_workspace]") {
+  std::string workspace_path = std::string(get_temp_dir())+"/"+workspace;
+
+  CHECK(!TileDBUtils::workspace_exists(workspace_path));
+  
+  CHECK(TileDBUtils::create_workspace(workspace_path, false) == TILEDB_OK);
+  CHECK(TileDBUtils::workspace_exists(workspace_path));
+  
+  CHECK(TileDBUtils::create_workspace(workspace_path, false) == TILEDB_ERR);
+  // workspace should still exist as its not overwritten
+  CHECK(TileDBUtils::workspace_exists(workspace_path));
+  
+  CHECK(TileDBUtils::create_workspace(workspace_path, true) == TILEDB_OK);
+  CHECK(TileDBUtils::workspace_exists(workspace_path));
+
+  std::string test_str("TESTING");
+  std::string test_file(workspace_path+"/test");
+  CHECK(TileDBUtils::write_file(test_file,test_str.c_str(), 4) == TILEDB_OK);
+  CHECK(posix_fs.is_file(test_file));
+
+  CHECK(TileDBUtils::create_workspace(workspace_path, true) == TILEDB_OK);
+  CHECK(TileDBUtils::workspace_exists(workspace_path));
+  // test file should not exist as the existing workspace was overwritten
+  CHECK(!(posix_fs.is_file(test_file) && posix_fs.is_dir(test_file)));
+
+  // Use defaults
+  CHECK(TileDBUtils::create_workspace(workspace_path) == TILEDB_ERR);
+  CHECK(posix_fs.delete_dir(workspace_path) == TILEDB_OK);
+
+  CHECK(TileDBUtils::create_workspace(workspace_path) == TILEDB_OK);
+}
+
+TEST_CASE_METHOD(TempDir, "Test array exists", "[array_exists]") {
+  std::string workspace_path = std::string(get_temp_dir())+"/"+workspace;
+  std::string non_existent_array = std::string("non_existent_array");
+
+  // No workspace or array
+  CHECK(!TileDBUtils::array_exists(workspace_path, non_existent_array));
+  
+  CHECK(TileDBUtils::create_workspace(workspace_path, false) == TILEDB_OK);
+  CHECK(TileDBUtils::workspace_exists(workspace_path));
+
+  // workspace exists but no array
+  CHECK(!TileDBUtils::array_exists(workspace_path, non_existent_array));
+
+  std::string input_ws = std::string(TILEDB_TEST_DIR)+"/inputs/compatibility_gdb_pre100_ws";
+  std::string array_name("t0_1_2");
+  CHECK(TileDBUtils::workspace_exists(input_ws));
+  CHECK(TileDBUtils::array_exists(input_ws, array_name));
+}
+
+TEST_CASE_METHOD(TempDir, "Test get fragment names", "[get_fragment_names]") {
+  std::string workspace_path = std::string(get_temp_dir())+"/"+workspace;
+
+  // No workspace or array or fragments
+  CHECK(TileDBUtils::get_fragment_names(workspace_path).size() == 0);
+
+  CHECK(TileDBUtils::create_workspace(workspace_path, false) == TILEDB_OK);
+  CHECK(TileDBUtils::workspace_exists(workspace_path));
+  
+  // No array or fragments
+  CHECK(TileDBUtils::get_fragment_names(workspace_path).size() == 0);
+
+  std::string input_ws = std::string(TILEDB_TEST_DIR)+"/inputs/compatibility_gdb_pre100_ws";
+  std::string array_name("t0_1_2");
+  CHECK(TileDBUtils::workspace_exists(input_ws));
+  CHECK(TileDBUtils::array_exists(input_ws, array_name));
+
+  // No fragments
+  CHECK(TileDBUtils::get_fragment_names(input_ws).size() == 0);
+
+  // TODO: Add input with one fragment
+}
+
+TEST_CASE_METHOD(TempDir, "Test file operations", "[file_ops]") {
+  std::string filename = std::string(get_temp_dir())+"/"+"test_file";
+  char buffer[1024];
+  memset(buffer, 'H', 1024);
+  CHECK(TileDBUtils::write_file(filename, buffer, 1024) == TILEDB_OK);
+
+  void *read_buffer = NULL;
+  size_t length;
+  CHECK(TileDBUtils::read_entire_file(filename, &read_buffer, &length) == TILEDB_OK);
+  CHECK(read_buffer);
+  CHECK(length == 1024);
+  for (auto i=0; i<1024; i++) {
+    char *ptr = (char *)(read_buffer)+i;
+    CHECK(*ptr == 'H');
+  }
+  free(read_buffer);
+
+  memset(buffer, 0, 1024);
+  CHECK(TileDBUtils::read_file(filename, 256, buffer, 256) == TILEDB_OK);
+  for (auto i=0; i<256; i++) {
+    CHECK(buffer[i] == 'H');
+  }
+
+  // read offset > filesize
+  memset(buffer, 0, 1024);
+  CHECK(TileDBUtils::read_file(filename, 1025, buffer, 256) == TILEDB_ERR);
+
+  // read past filesize
+  memset(buffer, 0, 1024);
+  CHECK(TileDBUtils::read_file(filename, 256, buffer, 1024) == TILEDB_ERR);
+
+  // read non-existent file
+  CHECK(TileDBUtils::read_entire_file(filename+".1", &read_buffer, &length) == TILEDB_ERR);
+  CHECK(TileDBUtils::read_file(filename+".1", 256, buffer, 256) == TILEDB_ERR);
+}
+
+TEST_CASE("Test create temp file", "[create_temp_file]") {
+  char path[PATH_MAX];
+  CHECK(TileDBUtils::create_temp_filename(path, PATH_MAX) == TILEDB_OK);
+  CHECK(TileDBUtils::delete_file(path) == TILEDB_OK);
+}

--- a/test/src/c_api/test_tiledb_utils.cc
+++ b/test/src/c_api/test_tiledb_utils.cc
@@ -102,7 +102,6 @@ class TempDir {
 };
 
 TEST_CASE_METHOD(TempDir, "Test initialize_workspace", "[initialize_workspace]") {
-  return;
   std::string workspace_path = get_temp_dir()+"/"+workspace;
 
   TileDB_CTX *tiledb_ctx;

--- a/test/src/c_api/test_tiledb_utils.cc
+++ b/test/src/c_api/test_tiledb_utils.cc
@@ -60,6 +60,7 @@ class TempDir {
       if (!delete_test_dir_in_destructor_.empty()) {
         delete_dir(tiledb_ctx, delete_test_dir_in_destructor_);
       }
+      CHECK(tiledb_ctx_finalize(tiledb_ctx) == TILEDB_OK);
     } else {
       if (strlen(get_temp_dir()) != 0) {
         posix_fs.delete_dir(get_temp_dir());
@@ -95,7 +96,6 @@ class TempDir {
       } else {
         snprintf(tmp_dir_, PATH_MAX, "%s/TileDBTest%d", g_test_dir.c_str(), test_num++);
       }
-      std::cerr << "Nalini" << tmp_dir_ << std::endl;
       TileDB_Config tiledb_config;
       memset(&tiledb_config, 0, sizeof(TileDB_Config));
       tiledb_config.home_ = g_test_dir.c_str();

--- a/test/src/c_api/test_tiledb_utils.cc
+++ b/test/src/c_api/test_tiledb_utils.cc
@@ -87,23 +87,16 @@ class TempDir {
         tmp_dir = P_tmpdir; // defined in stdio
       }
       assert(tmp_dir != NULL);
-          //snprintf(tmp_dir_, PATH_MAX, "%s%s", append_slash(tmp_dir).c_str(), dirname_pattern.c_str());
       tmp_dirname_ = mkdtemp(const_cast<char *>((append_slash(tmp_dir)+dirname_pattern).c_str()));
     } else {
-      //snprintf(tmp_dir_, PATH_MAX, "%s%s", append_slash(g_test_dir).c_str(), get_pathname(mktemp(dirname_pattern.c_str())).c_str());
       tmp_dirname_ = append_slash(g_test_dir)+mktemp(const_cast<char *>(dirname_pattern.c_str()));
-      TileDB_CTX *tiledb_ctx;
-      TileDB_Config tiledb_config;
-      tiledb_config.home_ = parent_dir(g_test_dir).c_str();
-      CHECK(tiledb_ctx_init(&tiledb_ctx, &tiledb_config) == 0);
-      if (!is_dir(tiledb_ctx, g_test_dir)) {
-        CHECK(create_dir(tiledb_ctx, g_test_dir) == 0);
+      if (!TileDBUtils::is_dir(g_test_dir)) {
+        CHECK(TileDBUtils::create_dir(g_test_dir) == 0);
         delete_test_dir_in_destructor_ = g_test_dir;
       }
-      if (!is_dir(tiledb_ctx, tmp_dirname_)) {
-        CHECK(create_dir(tiledb_ctx, tmp_dirname_) == TILEDB_OK);
+      if (!TileDBUtils::is_dir(tmp_dirname_)) {
+        CHECK(TileDBUtils::create_dir(tmp_dirname_) == TILEDB_OK);
       }
-      CHECK(tiledb_ctx_finalize(tiledb_ctx) == 0);
     }
   }
 };


### PR DESCRIPTION
Added unit test for tiledb_utils as this is going to be used extensively for ImageDS. In the process, cleaned up tiledb_utils and storage_posixfs.  

The existing delete_dir functionality in storage_posixfs did not work while testing. Moved it to use [nftw](https://linux.die.net/man/3/nftw) for recursive listing of directories for operations like delete as this is robust and the original implementation  was naive.

Also, have made test_tiledb_utils take an argument (--test-dir), so we can use it to test hdfs/gcs/s3/azure storage URLs in addition to posix. We were only running the examples on travis for a sanity check. Changed travis to run unit tests, only test_tiledb_utils for now, for distributed file systems.
