### PR TITLE
Modify unit tests to use TempDir to fix test_posix failures on NFS.

### DIFF
--- a/core/src/misc/utils.cc
+++ b/core/src/misc/utils.cc
@@ -356,7 +356,12 @@ std::string current_dir(StorageFS *fs) {
 }
 
 int set_working_dir(StorageFS *fs, const std::string& dir) {
-  return fs->set_working_dir(dir);
+  if (fs->is_dir(dir)) {
+    return fs->set_working_dir(dir);
+  } else {
+    UTILS_ERROR("Failed to set_working_dir as "+dir+" does not exist");
+    return TILEDB_UT_ERR;
+  }
 }
 
 std::vector<std::string> get_dirs(StorageFS *fs, const std::string& dir) {

--- a/test/include/catch2/catch.h
+++ b/test/include/catch2/catch.h
@@ -1,5 +1,7 @@
-#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
+
+#include "tiledb_utils.h"
 
 // Matchers
 using Catch::Equals;
@@ -9,3 +11,86 @@ using Catch::Contains;
 using Catch::Matches;
 
 #define CHECK_RC(rc, expected) CHECK(rc == expected)
+
+std::string g_test_dir = "";
+
+class TempDir {
+ public:
+  TempDir() {
+    create_temp_directory();
+  }
+
+  ~TempDir() {
+    TileDBUtils::delete_dir(get_temp_dir());
+
+    if (!delete_test_dir_in_destructor_.empty()) {
+      TileDBUtils::delete_dir(delete_test_dir_in_destructor_);
+    }
+  }
+
+  const std::string& get_temp_dir() {
+    return tmp_dirname_;
+  }
+ private:
+  std::string tmp_dirname_;
+  std::string delete_test_dir_in_destructor_;
+
+  std::string get_pathname(std::string  path) {
+    const size_t last_slash_idx = path.rfind('/');
+    if (last_slash_idx != std::string::npos) {
+      return path.substr(last_slash_idx+1);
+    } else {
+      return path;
+    }
+  }
+  std::string append_slash(std::string path) {
+    if (path[path.size()]!='/') {
+      return path+"/";
+    } else {
+      return path;
+    }
+  }
+  void create_temp_directory() {
+    std::string dirname_pattern("TileDBTestXXXXXX");
+    if (g_test_dir.empty()) { // Posix Case. Use mkdtemp() here
+      const char *tmp_dir = getenv("TMPDIR");
+      if (tmp_dir == NULL) {
+        tmp_dir = P_tmpdir; // defined in stdio
+      }
+      assert(tmp_dir != NULL);
+      tmp_dirname_ = mkdtemp(const_cast<char *>((append_slash(tmp_dir)+dirname_pattern).c_str()));
+    } else {
+      tmp_dirname_ = append_slash(g_test_dir)+mktemp(const_cast<char *>(dirname_pattern.c_str()));
+      if (!TileDBUtils::is_dir(g_test_dir)) {
+        CHECK(TileDBUtils::create_dir(g_test_dir) == 0);
+        delete_test_dir_in_destructor_ = g_test_dir;
+      }
+      if (!TileDBUtils::is_dir(tmp_dirname_)) {
+        CHECK(TileDBUtils::create_dir(tmp_dirname_) == TILEDB_OK);
+      }
+    }
+  }
+};
+
+int main( int argc, char* argv[] )
+{
+  Catch::Session session; // There must be exactly one instance
+
+  // Build a new parser on top of Catch's
+  using namespace Catch::clara;
+  auto cli
+    = session.cli() // Get Catch's composite command line parser
+    | Opt( g_test_dir, "Specify test dir, default is $TMPDIR" ) // bind variable to a new option, with a hint string
+     ["--test-dir"] // the option names it will respond to
+    ("Specify test dir, default is $TMPDIR if not specified");        // description string for the help output
+
+  // Now pass the new composite back to Catch so it uses that
+  session.cli(cli);
+
+  // Let Catch (using Clara) parse the command line
+  int rc = session.applyCommandLine( argc, argv );
+  if(rc != 0) // Indicates a command line error
+    return rc;
+
+  return session.run();
+}

--- a/test/src/c_api/test_tiledb_utils.cc
+++ b/test/src/c_api/test_tiledb_utils.cc
@@ -30,8 +30,7 @@
  * Unit Tests for tiledb_utils.cc 
  */
 
-#define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include "catch.h"
 
 #include "tiledb.h"
 #include "tiledb_storage.h"
@@ -41,65 +40,6 @@
 #include <fcntl.h>
 
 const std::string& workspace("WORKSPACE");
-std::string g_test_dir = "";
-
-class TempDir {
- public:
-  TempDir() {
-    create_temp_directory();
-  }
-
-  ~TempDir() {
-    TileDBUtils::delete_dir(get_temp_dir());
-
-    if (!delete_test_dir_in_destructor_.empty()) {
-      TileDBUtils::delete_dir(delete_test_dir_in_destructor_);
-    }
-  }
-
-  const std::string& get_temp_dir() {
-    return tmp_dirname_;
-  }
- private:
-  std::string tmp_dirname_;
-  std::string delete_test_dir_in_destructor_;
-
-  std::string get_pathname(std::string  path) {
-    const size_t last_slash_idx = path.rfind('/');
-    if (last_slash_idx != std::string::npos) {
-      return path.substr(last_slash_idx+1);
-    } else {
-      return path;
-    }
-  }
-  std::string append_slash(std::string path) {
-    if (path[path.size()]!='/') {
-      return path+"/";
-    } else {
-      return path;
-    }
-  }
-  void create_temp_directory() {
-    std::string dirname_pattern("TileDBTestXXXXXX");
-    if (g_test_dir.empty()) { // Posix Case. Use mkdtemp() here
-      const char *tmp_dir = getenv("TMPDIR");
-      if (tmp_dir == NULL) {
-        tmp_dir = P_tmpdir; // defined in stdio
-      }
-      assert(tmp_dir != NULL);
-      tmp_dirname_ = mkdtemp(const_cast<char *>((append_slash(tmp_dir)+dirname_pattern).c_str()));
-    } else {
-      tmp_dirname_ = append_slash(g_test_dir)+mktemp(const_cast<char *>(dirname_pattern.c_str()));
-      if (!TileDBUtils::is_dir(g_test_dir)) {
-        CHECK(TileDBUtils::create_dir(g_test_dir) == 0);
-        delete_test_dir_in_destructor_ = g_test_dir;
-      }
-      if (!TileDBUtils::is_dir(tmp_dirname_)) {
-        CHECK(TileDBUtils::create_dir(tmp_dirname_) == TILEDB_OK);
-      }
-    }
-  }
-};
 
 TEST_CASE_METHOD(TempDir, "Test initialize_workspace", "[initialize_workspace]") {
   std::string workspace_path = get_temp_dir()+"/"+workspace;
@@ -271,25 +211,3 @@ TEST_CASE_METHOD(TempDir, "Test move across filesystems", "[move_across_filesyst
   CHECK(!TileDBUtils::is_file(filename));
 }
 
-int main( int argc, char* argv[] )
-{
-  Catch::Session session; // There must be exactly one instance
-
-  // Build a new parser on top of Catch's
-  using namespace Catch::clara;
-  auto cli
-    = session.cli() // Get Catch's composite command line parser
-    | Opt( g_test_dir, "Specify test dir, default is $TMPDIR" ) // bind variable to a new option, with a hint string
-     ["--test-dir"] // the option names it will respond to
-    ("Specify test dir, default is $TMPDIR if not specified");        // description string for the help output
-
-  // Now pass the new composite back to Catch so it uses that
-  session.cli(cli);
-
-  // Let Catch (using Clara) parse the command line
-  int rc = session.applyCommandLine( argc, argv );
-  if(rc != 0) // Indicates a command line error
-    return rc;
-
-  return session.run();
-}

--- a/test/src/storage_manager/test_posixfs.cc
+++ b/test/src/storage_manager/test_posixfs.cc
@@ -44,22 +44,25 @@
 #include <string>
 #include <thread>
 
+#ifdef HAVE_OPENMP
+  #include <omp.h>
+#endif
 
 class PosixFSTestFixture {
  protected:
   PosixFS fs;
-  std::string test_dir = "test_posixfs_dir";
+  TempDir *td;
+  std::string test_dir;
 
   PosixFSTestFixture() {
+    td = new TempDir();
+    CHECK(fs.is_dir(td->get_temp_dir()));
+    test_dir = td->get_temp_dir()+"/test_posixfs_dir";
     CHECK(fs.locking_support());
   }
 
   ~PosixFSTestFixture() {
-    // Remove the temporary dir
-    std::string command = "rm -rf ";
-    command.append(test_dir);
-    CHECK_RC(system(command.c_str()), 0);
-    CHECK_RC(fs.sync_path("."), TILEDB_FS_OK);
+    delete td;
   }
  };
 
@@ -98,13 +101,14 @@ TEST_CASE_METHOD(PosixFSTestFixture, "Test PosixFS dir", "[dir]") {
   CHECK(fs.get_dirs(test_dir).size() == 0);
   CHECK(fs.get_dirs("non-existent-dir").size() == 0);
 
-  CHECK_RC(fs.move_path(test_dir, "new-dir"), TILEDB_FS_OK);
-  CHECK(fs.is_dir("new-dir"));
+  std::string new_dir = test_dir+"-new";
+  CHECK_RC(fs.move_path(test_dir, new_dir), TILEDB_FS_OK);
+  CHECK(fs.is_dir(new_dir));
   CHECK(!fs.is_dir(test_dir));
-  CHECK_RC(fs.move_path("new-dir", test_dir), TILEDB_FS_OK);
-  CHECK(!fs.is_dir("new-dir"));
+  CHECK_RC(fs.move_path(new_dir, test_dir), TILEDB_FS_OK);
+  CHECK(!fs.is_dir(new_dir));
   CHECK(fs.is_dir(test_dir));
-  CHECK_RC(fs.move_path("non-existent-dir", "new-dir"), TILEDB_FS_ERR);
+  CHECK_RC(fs.move_path("non-existent-dir", new_dir), TILEDB_FS_ERR);
   CHECK_RC(fs.move_path(test_dir, test_dir), TILEDB_FS_OK);
   CHECK(fs.is_dir(test_dir));
 
@@ -194,7 +198,9 @@ TEST_CASE_METHOD(PosixFSTestFixture, "Test PosixFS parallel operations", "[paral
   REQUIRE(fs.create_dir(test_dir) == TILEDB_FS_OK);
 
   bool complete = true;
-  uint iterations = std::thread::hardware_concurrency();
+  uint iterations = 4;
+
+  #pragma omp parallel for
   for (uint i=0; i<iterations; i++) {
     std::string filename = test_dir+"/foo"+std::to_string(i);
 
@@ -216,6 +222,7 @@ TEST_CASE_METHOD(PosixFSTestFixture, "Test PosixFS parallel operations", "[paral
   CHECK(fs.is_dir(test_dir+"new"));
 
   if (complete) {
+    #pragma omp parallel for
     for (uint i=0; i<iterations; i++) {
       std::string filename = test_dir+"new/foo"+std::to_string(i);
       CHECK(fs.is_file(filename));


### PR DESCRIPTION
Refactor TempDir out of TileDBTestUtils into catch.h to use everywhere. Otherwise, some test_posix tests are failing on NFS. In addition - moved the parallel unit tests in test_posix to use OpenMP when available and fix set_working_dir by checking if the dir exists as HDFS does not seem to be making the check.