### PR TITLE
Support new attribute types 

### DIFF
--- a/core/include/array/array_schema.h
+++ b/core/include/array/array_schema.h
@@ -440,9 +440,10 @@ class ArraySchema {
    * Sets the types. There should be one type per attribute plus one (the last
    * one) for the coordinates. 
    * The supported types for the attributes are:
-   *     - TILEDB_CHAR
-   *     - TILEDB_INT32
-   *     - TILEDB_INT64
+   *     - TILEDB_CHAR, TILEDB_INT8, TILEDB_UINT8
+   *     - TILEDB_INT16, TILEDB_UINT16
+   *     - TILEDB_INT32, TILEDB_UINT32
+   *     - TILEDB_INT64, TILDB_UINT64
    *     - TILEDB_FLOAT32
    *     - TILEDB_FLOAT64
    *

--- a/core/include/array/array_schema_c.h
+++ b/core/include/array/array_schema_c.h
@@ -118,11 +118,12 @@ typedef struct ArraySchemaC {
   /** 
    * The attribute types, plus an extra one in the end for the coordinates.
    * The attribute type can be one of the following: 
-   *    - TILEDB_INT32
-   *    - TILEDB_INT64
+   *    - TILEDB_INT32, TILEDB_UINT32
+   *    - TILEDB_INT64, TILEDB_UINT64
    *    - TILEDB_FLOAT32
    *    - TILEDB_FLOAT64
-   *    - TILEDB_CHAR 
+   *    - TILEDB_CHAR, TILEDB_INT8, TILEDB_UINT8
+   *    - TILEDB_INT16, TILEDB_UINT16
    *
    * The coordinate type can be one of the following: 
    *    - TILEDB_INT32

--- a/core/include/c_api/tiledb.h
+++ b/core/include/c_api/tiledb.h
@@ -289,11 +289,12 @@ typedef struct TileDB_ArraySchema {
   /** 
    * The attribute types, plus an extra one in the end for the coordinates.
    * The attribute type can be one of the following: 
-   *    - TILEDB_INT32
-   *    - TILEDB_INT64
+   *    - TILEDB_INT32, TILEDB_UINT32
+   *    - TILEDB_INT64, TILEDB_UINT64
    *    - TILEDB_FLOAT32
    *    - TILEDB_FLOAT64
-   *    - TILEDB_CHAR 
+   *    - TILEDB_CHAR, TILEDB_INT8, TILEDB_UINT8
+   *    - TILEDB_INT16, TILEDB_UINT16
    *
    * The coordinate type can be one of the following: 
    *    - TILEDB_INT32

--- a/core/include/c_api/tiledb_constants.h
+++ b/core/include/c_api/tiledb_constants.h
@@ -102,11 +102,17 @@
 
 /**@{*/
 /** Special empty cell value. */
-#define TILEDB_EMPTY_INT32                     INT_MAX
-#define TILEDB_EMPTY_INT64                   LLONG_MAX
+#define TILEDB_EMPTY_CHAR                      CHAR_MAX
+#define TILEDB_EMPTY_INT8                      INT8_MAX
+#define TILEDB_EMPTY_INT16                     INT16_MAX
+#define TILEDB_EMPTY_INT32                     INT32_MAX
+#define TILEDB_EMPTY_INT64                     INT64_MAX
+#define TILEDB_EMPTY_UINT8                     UINT8_MAX
+#define TILEDB_EMPTY_UINT16                    UINT16_MAX
+#define TILEDB_EMPTY_UINT32                    UINT32_MAX
+#define TILEDB_EMPTY_UINT64                    UINT64_MAX
 #define TILEDB_EMPTY_FLOAT32                   FLT_MAX
 #define TILEDB_EMPTY_FLOAT64                   DBL_MAX
-#define TILEDB_EMPTY_CHAR                     CHAR_MAX
 /**@}*/
 
 /**@{*/
@@ -122,6 +128,12 @@
 #define TILEDB_FLOAT32                               2
 #define TILEDB_FLOAT64                               3
 #define TILEDB_CHAR                                  4
+#define TILEDB_INT8                                  5
+#define TILEDB_UINT8                                 6
+#define TILEDB_INT16                                 7
+#define TILEDB_UINT16                                8
+#define TILEDB_UINT32                                9
+#define TILEDB_UINT64                               10
 /**@}*/
 
 /**@{*/

--- a/core/include/misc/utils.h
+++ b/core/include/misc/utils.h
@@ -924,7 +924,25 @@ inline T get_tiledb_empty_value();
 
 //Template specialization for get_tiledb_empty_value()
 template<>
-inline int get_tiledb_empty_value()
+inline char get_tiledb_empty_value()
+{
+  return TILEDB_EMPTY_CHAR;
+}
+
+template<>
+inline int8_t get_tiledb_empty_value()
+{
+  return TILEDB_EMPTY_INT8;
+}
+
+template<>
+inline int16_t get_tiledb_empty_value()
+{
+  return TILEDB_EMPTY_INT16;
+}
+
+template<>
+inline int32_t get_tiledb_empty_value()
 {
   return TILEDB_EMPTY_INT32;
 }
@@ -933,6 +951,30 @@ template<>
 inline int64_t get_tiledb_empty_value()
 {
   return TILEDB_EMPTY_INT64;
+}
+
+template<>
+inline uint8_t get_tiledb_empty_value()
+{
+  return TILEDB_EMPTY_UINT8;
+}
+
+template<>
+inline uint16_t get_tiledb_empty_value()
+{
+  return TILEDB_EMPTY_UINT16;
+}
+
+template<>
+inline uint32_t get_tiledb_empty_value()
+{
+  return TILEDB_EMPTY_UINT32;
+}
+
+template<>
+inline uint64_t get_tiledb_empty_value()
+{
+  return TILEDB_EMPTY_UINT64;
 }
 
 template<>
@@ -945,12 +987,6 @@ template<>
 inline double get_tiledb_empty_value()
 {
   return TILEDB_EMPTY_FLOAT64;
-}
-
-template<>
-inline char get_tiledb_empty_value()
-{
-  return TILEDB_EMPTY_CHAR;
 }
 
 #endif

--- a/core/src/array/array_read_state.cc
+++ b/core/src/array/array_read_state.cc
@@ -578,37 +578,37 @@ int ArrayReadState::copy_cells_var(
   // Invoke the proper templated function
   int rc = TILEDB_ARS_OK;
   if(type == TILEDB_CHAR)
-    copy_cells_var<char>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+    rc = copy_cells_var<char>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
                          buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_INT8)
-    copy_cells_var<int8_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+    rc = copy_cells_var<int8_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
                            buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_INT16)
-    copy_cells_var<int16_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+    rc = copy_cells_var<int16_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
                             buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_INT32)
-    copy_cells_var<int32_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+    rc = copy_cells_var<int32_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
                             buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_INT64)
-    copy_cells_var<int64_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+    rc = copy_cells_var<int64_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
                             buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_UINT8)
-    copy_cells_var<uint8_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+    rc = copy_cells_var<uint8_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
                             buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_UINT16)
-    copy_cells_var<uint16_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+    rc = copy_cells_var<uint16_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
                              buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_UINT32)
-    copy_cells_var<uint32_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+    rc = copy_cells_var<uint32_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
                              buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_UINT64)
-    copy_cells_var<uint64_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+    rc = copy_cells_var<uint64_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
                              buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_FLOAT32)
-    copy_cells_var<float>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+    rc = copy_cells_var<float>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
                           buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_FLOAT64)
-    copy_cells_var<double>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+    rc = copy_cells_var<double>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
                            buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else
     rc = TILEDB_ARS_ERR;

--- a/core/src/array/array_read_state.cc
+++ b/core/src/array/array_read_state.cc
@@ -434,42 +434,29 @@ int ArrayReadState::copy_cells(
   int type = array_schema_->type(attribute_id);
 
   // Invoke the proper templated function
-  int rc;
-  if(type == TILEDB_INT32)
-    rc = copy_cells<int>(
-             attribute_id, 
-             buffer, 
-             buffer_size, 
-             buffer_offset,
-             remaining_skip_count);
+  int rc = TILEDB_ARS_OK;
+  if(type == TILEDB_CHAR)
+    rc = copy_cells<char>(attribute_id, buffer, buffer_size, buffer_offset, remaining_skip_count);
+  else if(type == TILEDB_INT8)
+    rc = copy_cells<int8_t>(attribute_id, buffer, buffer_size, buffer_offset, remaining_skip_count);
+  else if(type == TILEDB_INT16)
+    rc = copy_cells<int16_t>(attribute_id, buffer, buffer_size, buffer_offset, remaining_skip_count);
+  else if(type == TILEDB_INT32)
+    rc = copy_cells<int32_t>(attribute_id, buffer, buffer_size, buffer_offset, remaining_skip_count);
   else if(type == TILEDB_INT64)
-    rc = copy_cells<int64_t>(
-             attribute_id, 
-             buffer, 
-             buffer_size, 
-             buffer_offset,
-             remaining_skip_count);
+    rc = copy_cells<int64_t>(attribute_id, buffer, buffer_size, buffer_offset, remaining_skip_count);
+  else if(type == TILEDB_UINT8)
+    rc = copy_cells<uint8_t>(attribute_id, buffer, buffer_size, buffer_offset, remaining_skip_count);
+  else if(type == TILEDB_UINT16)
+    rc = copy_cells<uint16_t>(attribute_id, buffer, buffer_size, buffer_offset, remaining_skip_count);
+  else if(type == TILEDB_UINT32)
+    rc = copy_cells<uint32_t>(attribute_id, buffer, buffer_size, buffer_offset, remaining_skip_count);
+  else if(type == TILEDB_UINT64)
+    rc = copy_cells<uint64_t>(attribute_id, buffer, buffer_size, buffer_offset, remaining_skip_count);
   else if(type == TILEDB_FLOAT32)
-    rc = copy_cells<float>(
-             attribute_id, 
-             buffer, 
-             buffer_size, 
-             buffer_offset,
-             remaining_skip_count);
+    rc = copy_cells<float>(attribute_id, buffer, buffer_size, buffer_offset, remaining_skip_count);
   else if(type == TILEDB_FLOAT64)
-    rc = copy_cells<double>(
-             attribute_id, 
-             buffer, 
-             buffer_size, 
-             buffer_offset,
-             remaining_skip_count);
-  else if(type == TILEDB_CHAR)
-    rc = copy_cells<char>(
-             attribute_id, 
-             buffer, 
-             buffer_size, 
-             buffer_offset,
-             remaining_skip_count);
+    rc = copy_cells<double>(attribute_id, buffer, buffer_size, buffer_offset, remaining_skip_count);
   else 
     rc = TILEDB_ARS_ERR;
 
@@ -589,62 +576,40 @@ int ArrayReadState::copy_cells_var(
   int type = array_schema_->type(attribute_id);
 
   // Invoke the proper templated function
-  int rc;
-  if(type == TILEDB_INT32)
-    rc = copy_cells_var<int>(
-             attribute_id,
-             buffer, 
-             buffer_size, 
-             buffer_offset,
-             remaining_skip_count,
-             buffer_var, 
-             buffer_var_size,
-             buffer_var_offset,
-             remaining_skip_count_var);
+  int rc = TILEDB_ARS_OK;
+  if(type == TILEDB_CHAR)
+    copy_cells_var<char>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+                         buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
+  else if(type == TILEDB_INT8)
+    copy_cells_var<int8_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+                           buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
+  else if(type == TILEDB_INT16)
+    copy_cells_var<int16_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+                            buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
+  else if(type == TILEDB_INT32)
+    copy_cells_var<int32_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+                            buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_INT64)
-    rc = copy_cells_var<int64_t>(
-             attribute_id,
-             buffer, 
-             buffer_size, 
-             buffer_offset,
-             remaining_skip_count,
-             buffer_var, 
-             buffer_var_size,
-             buffer_var_offset,
-             remaining_skip_count_var);
+    copy_cells_var<int64_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+                            buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
+  else if(type == TILEDB_UINT8)
+    copy_cells_var<uint8_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+                            buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
+  else if(type == TILEDB_UINT16)
+    copy_cells_var<uint16_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+                             buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
+  else if(type == TILEDB_UINT32)
+    copy_cells_var<uint32_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+                             buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
+  else if(type == TILEDB_UINT64)
+    copy_cells_var<uint64_t>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+                             buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_FLOAT32)
-    rc = copy_cells_var<float>(
-             attribute_id,
-             buffer, 
-             buffer_size, 
-             buffer_offset,
-             remaining_skip_count,
-             buffer_var, 
-             buffer_var_size,
-             buffer_var_offset,
-             remaining_skip_count_var);
+    copy_cells_var<float>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+                          buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else if(type == TILEDB_FLOAT64)
-    rc = copy_cells_var<double>(
-             attribute_id,
-             buffer, 
-             buffer_size, 
-             buffer_offset,
-             remaining_skip_count,
-             buffer_var, 
-             buffer_var_size,
-             buffer_var_offset,
-             remaining_skip_count_var);
-  else if(type == TILEDB_CHAR)
-    rc = copy_cells_var<char>(
-             attribute_id,
-             buffer, 
-             buffer_size, 
-             buffer_offset,
-             remaining_skip_count,
-             buffer_var, 
-             buffer_var_size,
-             buffer_var_offset,
-             remaining_skip_count_var);
+    copy_cells_var<double>(attribute_id, buffer, buffer_size, buffer_offset,remaining_skip_count,
+                           buffer_var, buffer_var_size, buffer_var_offset, remaining_skip_count_var);
   else
     rc = TILEDB_ARS_ERR;
 

--- a/core/src/array/array_schema.cc
+++ b/core/src/array/array_schema.cc
@@ -449,10 +449,22 @@ void ArraySchema::print() const {
   for(int i=0; i<attribute_num_; ++i) {
     if(types_[i] == TILEDB_CHAR) {
       std::cout << "\t" << attributes_[i] << ": char[";
+    } else if(types_[i] == TILEDB_INT8) {
+      std::cout << "\t" << attributes_[i] << ": int8[";
+    } else if(types_[i] == TILEDB_INT16) {
+      std::cout << "\t" << attributes_[i] << ": int16[";
     } else if(types_[i] == TILEDB_INT32) {
       std::cout << "\t" << attributes_[i] << ": int32[";
     } else if(types_[i] == TILEDB_INT64) {
       std::cout << "\t" << attributes_[i] << ": int64[";
+    } else if(types_[i] == TILEDB_UINT8) {
+      std::cout << "\t" << attributes_[i] << ": uint8[";
+    } else if(types_[i] == TILEDB_UINT16) {
+      std::cout << "\t" << attributes_[i] << ": uint16[";
+    } else if(types_[i] == TILEDB_UINT32) {
+      std::cout << "\t" << attributes_[i] << ": uint32[";
+    } else if(types_[i] == TILEDB_UINT64) {
+      std::cout << "\t" << attributes_[i] << ": uint64[";
     } else if(types_[i] == TILEDB_FLOAT32) {
       std::cout << "\t" << attributes_[i] << ": float32[";
     } else if(types_[i] == TILEDB_FLOAT64) {
@@ -1681,8 +1693,15 @@ int ArraySchema::set_types(const int* types) {
   
   // Set attribute types
   for(int i=0; i<attribute_num_; ++i) { 
-    if(types[i] != TILEDB_INT32 &&
+    if(types[i] != TILEDB_CHAR &&
+       types[i] != TILEDB_INT8 &&
+       types[i] != TILEDB_INT16 &&
+       types[i] != TILEDB_INT32 &&
        types[i] != TILEDB_INT64 &&
+       types[i] != TILEDB_UINT8 &&
+       types[i] != TILEDB_UINT16 &&
+       types[i] != TILEDB_UINT32 &&
+       types[i] != TILEDB_UINT64 &&
        types[i] != TILEDB_FLOAT32 &&
        types[i] != TILEDB_FLOAT64 &&
        types[i] != TILEDB_CHAR) {
@@ -2367,10 +2386,22 @@ size_t ArraySchema::compute_cell_size(int i) const {
   if(i < attribute_num_) {
     if(types_[i] == TILEDB_CHAR)
       size = cell_val_num_[i] * sizeof(char);
+    else if(types_[i] == TILEDB_INT8)
+      size = cell_val_num_[i] * sizeof(int8_t);
+    else if(types_[i] == TILEDB_INT16)
+      size = cell_val_num_[i] * sizeof(int16_t);
     else if(types_[i] == TILEDB_INT32)
-      size = cell_val_num_[i] * sizeof(int);
+      size = cell_val_num_[i] * sizeof(int32_t);
     else if(types_[i] == TILEDB_INT64)
       size = cell_val_num_[i] * sizeof(int64_t);
+    else if(types_[i] == TILEDB_UINT8)
+      size = cell_val_num_[i] * sizeof(uint8_t);
+    else if(types_[i] == TILEDB_UINT16)
+      size = cell_val_num_[i] * sizeof(uint16_t);
+    else if(types_[i] == TILEDB_UINT32)
+      size = cell_val_num_[i] * sizeof(uint32_t);
+    else if(types_[i] == TILEDB_UINT64)
+      size = cell_val_num_[i] * sizeof(uint64_t);
     else if(types_[i] == TILEDB_FLOAT32)
       size = cell_val_num_[i] * sizeof(float);
     else if(types_[i] == TILEDB_FLOAT64)
@@ -2495,10 +2526,22 @@ size_t ArraySchema::compute_type_size(int i) const {
 
   if(types_[i] == TILEDB_CHAR) {
     return sizeof(char);
+  } else if(types_[i] == TILEDB_INT8) {
+     return sizeof(int8_t);
+  } else if(types_[i] == TILEDB_INT16) {
+    return sizeof(int16_t);
   } else if(types_[i] == TILEDB_INT32) {
-    return sizeof(int);
+    return sizeof(int32_t);
   } else if(types_[i] == TILEDB_INT64) {
     return sizeof(int64_t);
+  } else if(types_[i] == TILEDB_UINT8) {
+     return sizeof(uint8_t);
+  } else if(types_[i] == TILEDB_UINT16) {
+    return sizeof(uint16_t);
+  } else if(types_[i] == TILEDB_UINT32) {
+    return sizeof(uint32_t);
+  } else if(types_[i] == TILEDB_UINT64) {
+    return sizeof(uint64_t);
   } else if(types_[i] == TILEDB_FLOAT32) {
     return sizeof(float);
   } else if(types_[i] == TILEDB_FLOAT64) {

--- a/core/src/array/array_sorted_read_state.cc
+++ b/core/src/array/array_sorted_read_state.cc
@@ -1626,7 +1626,7 @@ void ArraySortedReadState::handle_copy_requests_sparse() {
 void ArraySortedReadState::init_aio_requests() {
   for(int i=0; i<2; ++i) {
     aio_data_[i] = { i, 0, this };
-    aio_request_[i] = {};
+    memset(&aio_request_[i], 0, sizeof(AIO_Request));;
     aio_request_[i].buffer_sizes_ = buffer_sizes_tmp_[i];
     aio_request_[i].buffers_ = buffers_[i];
     aio_request_[i].mode_ = TILEDB_ARRAY_READ;

--- a/core/src/array/array_sorted_write_state.cc
+++ b/core/src/array/array_sorted_write_state.cc
@@ -1040,7 +1040,7 @@ void ArraySortedWriteState::fill_with_empty<char>(int bid) {
   size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
   char empty = TILEDB_EMPTY_CHAR;
 
-  // Fill with empty values_
+  // Fill with empty values
   size_t offset = 0;
   for(int64_t i=0; offset < local_buffer_size; offset += sizeof(char), ++i)
     local_buffer[i] = empty;

--- a/core/src/array/array_sorted_write_state.cc
+++ b/core/src/array/array_sorted_write_state.cc
@@ -1040,7 +1040,7 @@ void ArraySortedWriteState::fill_with_empty<char>(int bid) {
   size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
   char empty = TILEDB_EMPTY_CHAR;
 
-  // Fill with empty values
+  // Fill with empty values_
   size_t offset = 0;
   for(int64_t i=0; offset < local_buffer_size; offset += sizeof(char), ++i)
     local_buffer[i] = empty;
@@ -1049,9 +1049,9 @@ void ArraySortedWriteState::fill_with_empty<char>(int bid) {
 template<>
 void ArraySortedWriteState::fill_with_empty<int8_t>(int bid) {
   // For easy reference
-  int* local_buffer = (int*) copy_state_.buffers_[copy_id_][bid];
+  int8_t* local_buffer = (int8_t*) copy_state_.buffers_[copy_id_][bid];
   size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
-  int empty = TILEDB_EMPTY_INT8;
+  int8_t empty = TILEDB_EMPTY_INT8;
 
   // Fill with empty values
   size_t offset = 0;
@@ -1062,9 +1062,9 @@ void ArraySortedWriteState::fill_with_empty<int8_t>(int bid) {
 template<>
 void ArraySortedWriteState::fill_with_empty<int16_t>(int bid) {
   // For easy reference
-  int64_t* local_buffer = (int64_t*) copy_state_.buffers_[copy_id_][bid];
+  int16_t* local_buffer = (int16_t*) copy_state_.buffers_[copy_id_][bid];
   size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
-  int64_t empty = TILEDB_EMPTY_INT16;
+  int16_t empty = TILEDB_EMPTY_INT16;
 
   // Fill with empty values
   size_t offset = 0;
@@ -1075,9 +1075,9 @@ void ArraySortedWriteState::fill_with_empty<int16_t>(int bid) {
 template<>
 void ArraySortedWriteState::fill_with_empty<int32_t>(int bid) {
   // For easy reference
-  int* local_buffer = (int*) copy_state_.buffers_[copy_id_][bid];
+  int32_t* local_buffer = (int32_t*) copy_state_.buffers_[copy_id_][bid];
   size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
-  int empty = TILEDB_EMPTY_INT32;
+  int32_t empty = TILEDB_EMPTY_INT32;
 
   // Fill with empty values
   size_t offset = 0;
@@ -1101,9 +1101,9 @@ void ArraySortedWriteState::fill_with_empty<int64_t>(int bid) {
 template<>
 void ArraySortedWriteState::fill_with_empty<uint8_t>(int bid) {
   // For easy reference
-  int* local_buffer = (int*) copy_state_.buffers_[copy_id_][bid];
+  uint8_t* local_buffer = (uint8_t*) copy_state_.buffers_[copy_id_][bid];
   size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
-  int empty = TILEDB_EMPTY_UINT8;
+  uint8_t empty = TILEDB_EMPTY_UINT8;
 
   // Fill with empty values
   size_t offset = 0;
@@ -1114,9 +1114,9 @@ void ArraySortedWriteState::fill_with_empty<uint8_t>(int bid) {
 template<>
 void ArraySortedWriteState::fill_with_empty<uint16_t>(int bid) {
   // For easy reference
-  int64_t* local_buffer = (int64_t*) copy_state_.buffers_[copy_id_][bid];
+  uint16_t* local_buffer = (uint16_t*) copy_state_.buffers_[copy_id_][bid];
   size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
-  int64_t empty = TILEDB_EMPTY_UINT16;
+  uint16_t empty = TILEDB_EMPTY_UINT16;
 
   // Fill with empty values
   size_t offset = 0;
@@ -1127,9 +1127,9 @@ void ArraySortedWriteState::fill_with_empty<uint16_t>(int bid) {
 template<>
 void ArraySortedWriteState::fill_with_empty<uint32_t>(int bid) {
   // For easy reference
-  int* local_buffer = (int*) copy_state_.buffers_[copy_id_][bid];
+  uint32_t* local_buffer = (uint32_t*) copy_state_.buffers_[copy_id_][bid];
   size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
-  int empty = TILEDB_EMPTY_UINT32;
+  uint32_t empty = TILEDB_EMPTY_UINT32;
 
   // Fill with empty values
   size_t offset = 0;
@@ -1140,9 +1140,9 @@ void ArraySortedWriteState::fill_with_empty<uint32_t>(int bid) {
 template<>
 void ArraySortedWriteState::fill_with_empty<uint64_t>(int bid) {
   // For easy reference
-  int64_t* local_buffer = (int64_t*) copy_state_.buffers_[copy_id_][bid];
+  uint64_t* local_buffer = (uint64_t*) copy_state_.buffers_[copy_id_][bid];
   size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
-  int64_t empty = TILEDB_EMPTY_UINT64;
+  uint64_t empty = TILEDB_EMPTY_UINT64;
 
   // Fill with empty values
   size_t offset = 0;
@@ -1444,7 +1444,7 @@ void ArraySortedWriteState::init_aio_requests() {
   // Initialize AIO requests
   for(int i=0; i<2; ++i) {
     aio_data_[i] = { i, 0, this };
-    aio_request_[i] = {};
+    memset(&aio_request_[i], 0, sizeof(AIO_Request));
     aio_request_[i].id_ = (separate_fragments) ? aio_cnt_++ : 0;
     aio_request_[i].buffer_sizes_ = copy_state_.buffer_offsets_[i];
     aio_request_[i].buffers_ = copy_state_.buffers_[i];

--- a/core/src/array/array_sorted_write_state.cc
+++ b/core/src/array/array_sorted_write_state.cc
@@ -772,28 +772,52 @@ void ArraySortedWriteState::copy_tile_slab() {
   for(int i=0, b=0; i<(int)attribute_ids_.size(); ++i) {
     int type = array_schema->type(attribute_ids_[i]);
     if(!array_schema->var_size(attribute_ids_[i])) {
-      if(type == TILEDB_INT32)
-        copy_tile_slab<int>(i, b); 
+      if(type == TILEDB_CHAR)
+        copy_tile_slab<char>(i, b);
+      else if(type == TILEDB_INT8)
+        copy_tile_slab<int8_t>(i, b);
+      else if(type == TILEDB_INT16)
+        copy_tile_slab<int16_t>(i, b);
+      else if(type == TILEDB_INT32)
+        copy_tile_slab<int32_t>(i, b);
       else if(type == TILEDB_INT64)
         copy_tile_slab<int64_t>(i, b); 
+      else if(type == TILEDB_UINT8)
+        copy_tile_slab<uint8_t>(i, b);
+      else if(type == TILEDB_UINT16)
+         copy_tile_slab<uint16_t>(i, b);
+      else if(type == TILEDB_UINT32)
+        copy_tile_slab<uint32_t>(i, b);
+      else if(type == TILEDB_UINT64)
+        copy_tile_slab<uint64_t>(i, b);
       else if(type == TILEDB_FLOAT32)
         copy_tile_slab<float>(i, b); 
       else if(type == TILEDB_FLOAT64)
         copy_tile_slab<double>(i, b); 
-      else if(type == TILEDB_CHAR)
-        copy_tile_slab<char>(i, b); 
       ++b;
     } else {
-      if(type == TILEDB_INT32)
-        copy_tile_slab_var<int>(i, b); 
+      if(type == TILEDB_CHAR)
+        copy_tile_slab_var<char>(i, b);
+      else if(type == TILEDB_INT8)
+        copy_tile_slab_var<int8_t>(i, b);
+      else if(type == TILEDB_INT16)
+        copy_tile_slab_var<int16_t>(i, b);
+      else if(type == TILEDB_INT32)
+        copy_tile_slab_var<int32_t>(i, b); 
       else if(type == TILEDB_INT64)
         copy_tile_slab_var<int64_t>(i, b); 
+      else if(type == TILEDB_UINT8)
+        copy_tile_slab_var<uint8_t>(i, b);
+      else if(type == TILEDB_UINT16)
+         copy_tile_slab_var<uint16_t>(i, b);
+      else if(type == TILEDB_UINT32)
+        copy_tile_slab_var<uint32_t>(i, b);
+      else if(type == TILEDB_UINT64)
+        copy_tile_slab_var<uint64_t>(i, b);
       else if(type == TILEDB_FLOAT32)
         copy_tile_slab_var<float>(i, b); 
       else if(type == TILEDB_FLOAT64)
-        copy_tile_slab_var<double>(i, b); 
-      else if(type == TILEDB_CHAR)
-        copy_tile_slab_var<char>(i, b); 
+        copy_tile_slab_var<double>(i, b);  
       b += 2;
     }
   }
@@ -1007,8 +1031,49 @@ void ArraySortedWriteState::create_user_buffers(
     buffer_offsets_[i] = 0;
 }
 
+// Specializations for fill_with_empty
+
 template<>
-void ArraySortedWriteState::fill_with_empty<int>(int bid) {
+void ArraySortedWriteState::fill_with_empty<char>(int bid) {
+  // For easy reference
+  char* local_buffer = (char*) copy_state_.buffers_[copy_id_][bid];
+  size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
+  char empty = TILEDB_EMPTY_CHAR;
+
+  // Fill with empty values
+  size_t offset = 0;
+  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(char), ++i)
+    local_buffer[i] = empty;
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty<int8_t>(int bid) {
+  // For easy reference
+  int* local_buffer = (int*) copy_state_.buffers_[copy_id_][bid];
+  size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
+  int empty = TILEDB_EMPTY_INT8;
+
+  // Fill with empty values
+  size_t offset = 0;
+  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(int8_t), ++i)
+    local_buffer[i] = empty;
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty<int16_t>(int bid) {
+  // For easy reference
+  int64_t* local_buffer = (int64_t*) copy_state_.buffers_[copy_id_][bid];
+  size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
+  int64_t empty = TILEDB_EMPTY_INT16;
+
+  // Fill with empty values
+  size_t offset = 0;
+  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(int16_t), ++i)
+    local_buffer[i] = empty;
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty<int32_t>(int bid) {
   // For easy reference
   int* local_buffer = (int*) copy_state_.buffers_[copy_id_][bid];
   size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
@@ -1016,7 +1081,7 @@ void ArraySortedWriteState::fill_with_empty<int>(int bid) {
 
   // Fill with empty values
   size_t offset = 0;
-  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(int), ++i) 
+  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(int32_t), ++i)
     local_buffer[i] = empty;
 }
 
@@ -1029,7 +1094,59 @@ void ArraySortedWriteState::fill_with_empty<int64_t>(int bid) {
 
   // Fill with empty values
   size_t offset = 0;
-  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(int64_t), ++i) 
+  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(int64_t), ++i)
+    local_buffer[i] = empty;
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty<uint8_t>(int bid) {
+  // For easy reference
+  int* local_buffer = (int*) copy_state_.buffers_[copy_id_][bid];
+  size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
+  int empty = TILEDB_EMPTY_UINT8;
+
+  // Fill with empty values
+  size_t offset = 0;
+  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(uint8_t), ++i)
+    local_buffer[i] = empty;
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty<uint16_t>(int bid) {
+  // For easy reference
+  int64_t* local_buffer = (int64_t*) copy_state_.buffers_[copy_id_][bid];
+  size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
+  int64_t empty = TILEDB_EMPTY_UINT16;
+
+  // Fill with empty values
+  size_t offset = 0;
+  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(uint16_t), ++i)
+    local_buffer[i] = empty;
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty<uint32_t>(int bid) {
+  // For easy reference
+  int* local_buffer = (int*) copy_state_.buffers_[copy_id_][bid];
+  size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
+  int empty = TILEDB_EMPTY_UINT32;
+
+  // Fill with empty values
+  size_t offset = 0;
+  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(uint32_t), ++i)
+    local_buffer[i] = empty;
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty<uint64_t>(int bid) {
+  // For easy reference
+  int64_t* local_buffer = (int64_t*) copy_state_.buffers_[copy_id_][bid];
+  size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
+  int64_t empty = TILEDB_EMPTY_UINT64;
+
+  // Fill with empty values
+  size_t offset = 0;
+  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(uint64_t), ++i)
     local_buffer[i] = empty;
 }
 
@@ -1042,7 +1159,7 @@ void ArraySortedWriteState::fill_with_empty<float>(int bid) {
 
   // Fill with empty values
   size_t offset = 0;
-  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(float), ++i) 
+  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(float), ++i)
     local_buffer[i] = empty;
 }
 
@@ -1055,32 +1172,54 @@ void ArraySortedWriteState::fill_with_empty<double>(int bid) {
 
   // Fill with empty values
   size_t offset = 0;
-  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(double), ++i) 
+  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(double), ++i)
     local_buffer[i] = empty;
 }
 
+// Specializations for fill_with_empty_var
+
 template<>
-void ArraySortedWriteState::fill_with_empty<char>(int bid) {
+void ArraySortedWriteState::fill_with_empty_var<char>(int bid) {
   // For easy reference
-  char* local_buffer = (char*) copy_state_.buffers_[copy_id_][bid];
-  size_t local_buffer_size = copy_state_.buffer_sizes_[copy_id_][bid];
+  char* local_buffer_var = (char*) copy_state_.buffers_[copy_id_][bid+1];
+  size_t local_buffer_offset_var = copy_state_.buffer_offsets_[copy_id_][bid+1];
   char empty = TILEDB_EMPTY_CHAR;
 
-  // Fill with empty values
-  size_t offset = 0;
-  for(int64_t i=0; offset < local_buffer_size; offset += sizeof(char), ++i) 
-    local_buffer[i] = empty;
+  // Fill an empty value
+  memcpy(local_buffer_var + local_buffer_offset_var, &empty, sizeof(char));
 }
 
 template<>
-void ArraySortedWriteState::fill_with_empty_var<int>(int bid) {
+void ArraySortedWriteState::fill_with_empty_var<int8_t>(int bid) {
+  // For easy reference
+  char* local_buffer_var = (char*) copy_state_.buffers_[copy_id_][bid+1];
+  size_t local_buffer_offset_var = copy_state_.buffer_offsets_[copy_id_][bid+1];
+  int empty = TILEDB_EMPTY_INT8;
+
+  // Fill an empty value
+  memcpy(local_buffer_var + local_buffer_offset_var, &empty, sizeof(int8_t));
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty_var<int16_t>(int bid) {
+  // For easy reference
+  char* local_buffer_var = (char*) copy_state_.buffers_[copy_id_][bid+1];
+  size_t local_buffer_offset_var = copy_state_.buffer_offsets_[copy_id_][bid+1];
+  int64_t empty = TILEDB_EMPTY_INT16;
+
+  // Fill an empty value
+  memcpy(local_buffer_var + local_buffer_offset_var, &empty, sizeof(int16_t));
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty_var<int32_t>(int bid) {
   // For easy reference
   char* local_buffer_var = (char*) copy_state_.buffers_[copy_id_][bid+1];
   size_t local_buffer_offset_var = copy_state_.buffer_offsets_[copy_id_][bid+1];
   int empty = TILEDB_EMPTY_INT32;
 
   // Fill an empty value
-  memcpy(local_buffer_var + local_buffer_offset_var, &empty, sizeof(int));
+  memcpy(local_buffer_var + local_buffer_offset_var, &empty, sizeof(int32_t));
 }
 
 template<>
@@ -1092,6 +1231,50 @@ void ArraySortedWriteState::fill_with_empty_var<int64_t>(int bid) {
 
   // Fill an empty value
   memcpy(local_buffer_var + local_buffer_offset_var, &empty, sizeof(int64_t));
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty_var<uint8_t>(int bid) {
+  // For easy reference
+  char* local_buffer_var = (char*) copy_state_.buffers_[copy_id_][bid+1];
+  size_t local_buffer_offset_var = copy_state_.buffer_offsets_[copy_id_][bid+1];
+  int empty = TILEDB_EMPTY_UINT8;
+
+  // Fill an empty value
+  memcpy(local_buffer_var + local_buffer_offset_var, &empty, sizeof(uint8_t));
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty_var<uint16_t>(int bid) {
+  // For easy reference
+  char* local_buffer_var = (char*) copy_state_.buffers_[copy_id_][bid+1];
+  size_t local_buffer_offset_var = copy_state_.buffer_offsets_[copy_id_][bid+1];
+  int64_t empty = TILEDB_EMPTY_UINT16;
+
+  // Fill an empty value
+  memcpy(local_buffer_var + local_buffer_offset_var, &empty, sizeof(uint16_t));
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty_var<uint32_t>(int bid) {
+  // For easy reference
+  char* local_buffer_var = (char*) copy_state_.buffers_[copy_id_][bid+1];
+  size_t local_buffer_offset_var = copy_state_.buffer_offsets_[copy_id_][bid+1];
+  int empty = TILEDB_EMPTY_UINT32;
+
+  // Fill an empty value
+  memcpy(local_buffer_var + local_buffer_offset_var, &empty, sizeof(uint32_t));
+}
+
+template<>
+void ArraySortedWriteState::fill_with_empty_var<uint64_t>(int bid) {
+  // For easy reference
+  char* local_buffer_var = (char*) copy_state_.buffers_[copy_id_][bid+1];
+  size_t local_buffer_offset_var = copy_state_.buffer_offsets_[copy_id_][bid+1];
+  int64_t empty = TILEDB_EMPTY_UINT64;
+
+  // Fill an empty value
+  memcpy(local_buffer_var + local_buffer_offset_var, &empty, sizeof(uint64_t));
 }
 
 template<>
@@ -1114,17 +1297,6 @@ void ArraySortedWriteState::fill_with_empty_var<double>(int bid) {
 
   // Fill an empty value
   memcpy(local_buffer_var + local_buffer_offset_var, &empty, sizeof(double));
-}
-
-template<>
-void ArraySortedWriteState::fill_with_empty_var<char>(int bid) {
-  // For easy reference
-  char* local_buffer_var = (char*) copy_state_.buffers_[copy_id_][bid+1];
-  size_t local_buffer_offset_var = copy_state_.buffer_offsets_[copy_id_][bid+1];
-  char empty = TILEDB_EMPTY_CHAR;
-
-  // Fill an empty value
-  memcpy(local_buffer_var + local_buffer_offset_var, &empty, sizeof(char));
 }
 
 void ArraySortedWriteState::free_copy_state() {

--- a/core/src/codec/codec_rle.cc
+++ b/core/src/codec/codec_rle.cc
@@ -101,7 +101,7 @@ int CodecRLE::decompress_tile(unsigned char* tile_compressed,  size_t tile_compr
   int rc;
   if(!is_coords_) { 
     rc = RLE_decompress(
-             (unsigned char*) tile_compressed_, 
+             (unsigned char*) tile_compressed,
              tile_compressed_size,
              tile, 
              tile_size,
@@ -109,7 +109,7 @@ int CodecRLE::decompress_tile(unsigned char* tile_compressed,  size_t tile_compr
   } else {
     if(cell_order_ == TILEDB_ROW_MAJOR) {
       rc = RLE_decompress_coords_row(
-               (unsigned char*) tile_compressed_, 
+               (unsigned char*) tile_compressed,
                tile_compressed_size,
                tile, 
                tile_size,
@@ -117,7 +117,7 @@ int CodecRLE::decompress_tile(unsigned char* tile_compressed,  size_t tile_compr
                dim_num_);
     } else if(cell_order_ == TILEDB_COL_MAJOR) {
       rc = RLE_compress_coords_col(
-               (unsigned char*) tile_compressed_, 
+               (unsigned char*) tile_compressed, 
                tile_compressed_size,
                tile, 
                tile_size,

--- a/test/include/c_api/c_api_array_schema_spec.h
+++ b/test/include/c_api/c_api_array_schema_spec.h
@@ -75,7 +75,9 @@ class ArraySchemaTestFixture {
    *
    * @return TILEDB_OK on success and TILEDB_ERR on error.
    */
-  int create_dense_array();
+  int create_dense_array(std::string array_name, int attribute_datatype, int compression_type);
+
+  void check_dense_array(std::string array_name);
 
 
   /* ********************************* */

--- a/test/include/c_api/c_api_dense_array_spec.h
+++ b/test/include/c_api/c_api_dense_array_spec.h
@@ -84,6 +84,25 @@ class DenseArrayTestFixture {
               const int64_t domain_size_1,
               const int64_t update_num);
 
+ /**
+   * Creates a 1D dense array.
+   *
+   * @param attribute_type
+   * @param tile_extent
+   * @param domain_lo
+   * @param domain_hi
+   * @param cell_order The cell order.
+   * @param tile_order The tile order.
+   * @return TILEDB_OK on success and TILEDB_ERR on error.
+   */
+  int create_dense_array_1D(
+      const int attribute_type,
+      const int32_t tile_extent,
+      const int32_t domain_lo,
+      const int32_t domain_hi,
+      const int cell_order,
+      const int tile_order);
+
   /**
    * Creates a 2D dense array.
    *

--- a/test/include/c_api/c_api_sparse_array_spec.h
+++ b/test/include/c_api/c_api_sparse_array_spec.h
@@ -61,6 +61,25 @@ class SparseArrayTestFixture {
   /* ********************************* */
 
   /**
+   * Creates a 1D sparse array.
+   *
+   * @param attribute_type
+   * @param tile_extent
+   * @param domain_lo
+   * @param domain_hi
+   * @param cell_order The cell order.
+   * @param tile_order The tile order.
+   * @return TILEDB_OK on success and TILEDB_ERR on error.
+   */
+  int create_sparse_array_1D(
+    const int attribute_type,
+    const int32_t tile_extent,
+    const int32_t domain_lo,
+    const int32_t domain_hi,
+    const int cell_order,
+    const int tile_order);
+
+  /**
    * Creates a 2D sparse array.
    *
    * @param tile_extent_0 The tile extent along the first dimension. 

--- a/test/src/c_api/test_array_schema_api.cc
+++ b/test/src/c_api/test_array_schema_api.cc
@@ -87,22 +87,22 @@ ArraySchemaTestFixture::~ArraySchemaTestFixture() {
 /*         PUBLIC METHODS         */
 /* ****************************** */
 
-int ArraySchemaTestFixture::create_dense_array() {
+int ArraySchemaTestFixture::create_dense_array(std::string array_name, int attribute_datatype, int compression_type) {
   // Initialization s
   int rc;
-  const char* attributes[] = { "ATTR_INT32" };
+  const char* attributes[] = { "MY_ATTRIBUTE" };
   const char* dimensions[] = { "X", "Y" };
   int64_t domain[] = { 0, 99, 0, 99 };
   int64_t tile_extents[] = { 10, 10 };
-  const int types[] = { TILEDB_INT32, TILEDB_INT64 };
-  const int compression[] = { TILEDB_NO_COMPRESSION, TILEDB_NO_COMPRESSION };
+  const int types[] = { attribute_datatype, TILEDB_INT64 };
+  const int compression[] = { compression_type, TILEDB_NO_COMPRESSION };
 
   // Set array schema
   rc = tiledb_array_set_schema(
       // The array schema structure
       &array_schema_,
       // Array name
-      array_name_.c_str(),
+      array_name.c_str(),
       // Attributes
       attributes,
       // Number of attributes
@@ -146,29 +146,14 @@ int ArraySchemaTestFixture::create_dense_array() {
   return tiledb_array_create(tiledb_ctx_, &array_schema_);
 }
 
-
-
-
-/* ****************************** */
-/*             TESTS              */
-/* ****************************** */
-
-/**
- * Tests the array schema creation and retrieval.
- */
-TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema", "[array_schema]") {
-  // Error code 
+void ArraySchemaTestFixture::check_dense_array(std::string array_name) {
   int rc;
-
-  // Create array
-  rc = create_dense_array();
-  REQUIRE(rc == TILEDB_OK);
 
   // Load array schema from the disk
   TileDB_ArraySchema array_schema_disk;
   rc = tiledb_array_load_schema(
            tiledb_ctx_, 
-           array_name_.c_str(), 
+           array_name.c_str(), 
            &array_schema_disk);
   REQUIRE(rc == TILEDB_OK);
 
@@ -179,9 +164,9 @@ TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema", "[array_schema]") 
       static_cast<int64_t*>(array_schema_.tile_extents_);
 
   // Get real array path
-  std::string array_name_real = fs_.real_dir(array_name_);
+  std::string array_name_real = fs_.real_dir(array_name);
   CHECK_FALSE(array_name_real == "");
-  CHECK_THAT(array_name_real, EndsWith(ARRAYNAME));
+  CHECK_THAT(array_name_real, EndsWith(array_name));
 
   // Tests
   //absolute path isn't relevant anymore
@@ -206,6 +191,116 @@ TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema", "[array_schema]") 
 }
 
 
+
+
+/* ****************************** */
+/*             TESTS              */
+/* ****************************** */
+
+/**
+ * Tests the array schema creation and retrieval.
+ */
+TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema char", "[array_schema_char]") {
+  std::string array_name = array_name_ + "char";
+
+  // Create array
+  int rc = create_dense_array(array_name, TILEDB_CHAR, TILEDB_NO_COMPRESSION);
+  REQUIRE(rc == TILEDB_OK);
+
+  check_dense_array(array_name);
+}
+
+TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema int8", "[array_schema_int8]") {
+  std::string array_name = array_name_ + "int8";
+
+  // Create array
+  int rc = create_dense_array(array_name, TILEDB_INT8, TILEDB_NO_COMPRESSION);
+  REQUIRE(rc == TILEDB_OK);
+
+  check_dense_array(array_name);
+}
+
+TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema int16", "[array_schema_int16]") {
+  std::string array_name = array_name_ + "int16";
+
+  // Create array
+  int rc = create_dense_array(array_name, TILEDB_INT16, TILEDB_ZSTD);
+  REQUIRE(rc == TILEDB_OK);
+
+  check_dense_array(array_name);
+}
+
+TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema int32", "[array_schema_int32]") {
+  std::string array_name = array_name_ + "int32";
+
+  // Create array
+  int rc = create_dense_array(array_name, TILEDB_INT32, TILEDB_LZ4);
+  REQUIRE(rc == TILEDB_OK);
+
+  check_dense_array(array_name);
+}
+
+TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema int64", "[array_schema_int64]") {
+  std::string array_name = array_name_ + "int64";
+
+  // Create array
+  int rc = create_dense_array(array_name, TILEDB_INT64, TILEDB_BLOSC);
+  REQUIRE(rc == TILEDB_OK);
+
+  check_dense_array(array_name);
+}
+
+TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema uint8", "[array_schema_uint8]") {
+  std::string array_name = array_name_ + "uint8";
+
+  // Create array
+  int rc = create_dense_array(array_name, TILEDB_UINT8, TILEDB_GZIP);
+  REQUIRE(rc == TILEDB_OK);
+
+  check_dense_array(array_name);
+}
+
+TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema uint16", "[array_schema_uint16]") {
+  std::string array_name = array_name_ + "uint16";
+
+  // Create array
+  int rc = create_dense_array(array_name, TILEDB_UINT16, TILEDB_ZSTD);
+  REQUIRE(rc == TILEDB_OK);
+
+  check_dense_array(array_name);
+}
+
+TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema uint32", "[array_schema_uint32]") {
+  std::string array_name = array_name_ + "uint32";
+
+  // Create array
+  int rc = create_dense_array(array_name, TILEDB_UINT32, TILEDB_LZ4);
+  REQUIRE(rc == TILEDB_OK);
+
+  check_dense_array(array_name);
+}
+
+TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema float32", "[array_schema_float32]") {
+  std::string array_name = array_name_ + "float32";
+
+  // Create array
+  int rc = create_dense_array(array_name, TILEDB_FLOAT32, TILEDB_RLE);
+  REQUIRE(rc == TILEDB_OK);
+
+  check_dense_array(array_name);
+}
+
+TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema float64", "[array_schema_float64]") {
+  std::string array_name = array_name_ + "float64";
+
+  // Create array
+  int rc = create_dense_array(array_name, TILEDB_FLOAT64, TILEDB_BLOSC);
+  REQUIRE(rc == TILEDB_OK);
+
+  check_dense_array(array_name);
+}
+
+
 TEST_CASE("Test array schema backward compatibility", "[compatibility]") {
   TileDB_CTX* tiledb_ctx;
   int rc = tiledb_ctx_init(&tiledb_ctx, NULL);
@@ -226,3 +321,4 @@ TEST_CASE("Test array schema backward compatibility", "[compatibility]") {
   CHECK(array_schema.dim_num_ == 2);
   CHECK(array_schema.compression_[0] == 1);
 }
+

--- a/test/src/c_api/test_array_schema_api.cc
+++ b/test/src/c_api/test_array_schema_api.cc
@@ -280,6 +280,16 @@ TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema uint32", "[array_sch
   check_dense_array(array_name);
 }
 
+TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema uint64", "[array_schema_uint64]") {
+  std::string array_name = array_name_ + "uint64";
+
+  // Create array
+  int rc = create_dense_array(array_name, TILEDB_UINT64, TILEDB_LZ4);
+  REQUIRE(rc == TILEDB_OK);
+
+  check_dense_array(array_name);
+}
+
 TEST_CASE_METHOD(ArraySchemaTestFixture, "Test Array Schema float32", "[array_schema_float32]") {
   std::string array_name = array_name_ + "float32";
 

--- a/test/src/c_api/test_dense_array_api.cc
+++ b/test/src/c_api/test_dense_array_api.cc
@@ -160,8 +160,8 @@ int DenseArrayTestFixture::create_dense_array_1D(
   int32_t domain[] = { domain_lo, domain_hi };
   int32_t tile_extents[] = { tile_extent };
   const int types[] = { attribute_type, TILEDB_INT32 };
-  int compression[] = { TILEDB_NO_COMPRESSION };
-  int compression_level[] = { 0 };
+  int compression[] = { TILEDB_NO_COMPRESSION, TILEDB_NO_COMPRESSION };
+  int compression_level[] = { 0, 0 };
   const int dense = 1;
 
   // Set the array schema

--- a/test/src/c_api/test_sparse_array_api.cc
+++ b/test/src/c_api/test_sparse_array_api.cc
@@ -74,6 +74,236 @@ SparseArrayTestFixture::~SparseArrayTestFixture() {
 /*          PUBLIC METHODS        */
 /* ****************************** */
 
+template <typename T> 
+void* create_buffer(int32_t size, T** buffer, size_t* bytes) {
+  T *typed_buffer= *buffer;
+  typed_buffer = new T[size];
+  *bytes = (size)*sizeof(T);
+  for(int32_t i = 0; i < size; ++i)
+    typed_buffer[i] = (T)i;
+  return reinterpret_cast<void *>(typed_buffer);
+}
+
+template <typename T>
+void clear_buffer(int32_t size, T* buffer) {
+  for(int32_t i = 0; i < size; ++i)
+    buffer[i] = (T)0;
+}
+
+template <typename T>
+void validate_and_cleanup_buffer(int32_t size, T* buffer) {
+  for(int32_t i = 0; i < size; ++i)
+    CHECK(buffer[i] == (T)i);
+  delete buffer;
+}
+
+int SparseArrayTestFixture::create_sparse_array_1D(
+    const int attribute_type,
+    const int32_t tile_extent,
+    const int32_t domain_lo,
+    const int32_t domain_hi,
+    const int cell_order,
+    const int tile_order) {
+  // Error code
+  int rc;
+
+  // Setup array
+  const int attribute_num = 1;
+  const char* attributes[] = { "MY_ATTRIBUTE" };
+  const char* dimensions[] = { "X"};
+  int32_t domain[] = { domain_lo, domain_hi };
+  int32_t tile_extents[] = { tile_extent };
+  const int types[] = { attribute_type, TILEDB_INT32 };
+  int compression[] = { TILEDB_NO_COMPRESSION, TILEDB_NO_COMPRESSION};
+  int compression_level[] = { 0, 0 };
+
+  // Set the array schema
+  rc = tiledb_array_set_schema(
+      &array_schema_,
+           array_name_.c_str(),
+           attributes,
+           attribute_num,
+           0,
+           cell_order,
+           NULL,
+           compression,
+	   compression_level,
+           0, // Sparse
+           dimensions,
+           1,
+           domain,
+           2*sizeof(int32_t),
+           tile_extents,
+           sizeof(int32_t),
+           tile_order,
+           types);
+  if(rc != TILEDB_OK)
+    return TILEDB_ERR;
+
+  // Create the array
+  rc = tiledb_array_create(tiledb_ctx_, &array_schema_);
+  if(rc != TILEDB_OK)
+    return TILEDB_ERR;
+
+  // Free array schema
+  rc = tiledb_array_free_schema(&array_schema_);
+  if(rc != TILEDB_OK)
+    return TILEDB_ERR;
+
+  int32_t domain_size = domain_hi-domain_lo+1;
+  size_t nbytes = domain_size/10;
+
+  int32_t* buffer_coords = new int32_t[nbytes];
+  for (int32_t i = 0; i < nbytes; ++i) {
+    buffer_coords[i] = i;
+  }
+  size_t buffer_coords_size = nbytes * sizeof(int32_t);
+  
+  void *buffer = nullptr;
+  if (attribute_type == TILEDB_CHAR) {
+    char *typed_buffer = reinterpret_cast<char *>(buffer);
+    buffer = create_buffer(nbytes, &typed_buffer, &nbytes);
+  } else if (attribute_type == TILEDB_INT8) {
+    int8_t *typed_buffer = reinterpret_cast<int8_t *>(buffer);
+    buffer = create_buffer(nbytes, &typed_buffer, &nbytes);
+  } else if (attribute_type == TILEDB_INT16) {
+    int16_t *typed_buffer = reinterpret_cast<int16_t *>(buffer);
+    buffer = create_buffer(nbytes, &typed_buffer, &nbytes);
+  } else if (attribute_type == TILEDB_INT32) {
+    int32_t *typed_buffer = reinterpret_cast<int32_t *>(buffer);
+    buffer = create_buffer(nbytes, &typed_buffer, &nbytes);
+  } else if (attribute_type == TILEDB_INT64) {
+    int64_t *typed_buffer = reinterpret_cast<int64_t *>(buffer);
+    buffer = create_buffer(nbytes, &typed_buffer, &nbytes);
+  } else if (attribute_type == TILEDB_UINT8) {
+    uint8_t *typed_buffer = reinterpret_cast<uint8_t *>(buffer);
+    buffer = create_buffer(nbytes, &typed_buffer, &nbytes);
+  } else if (attribute_type == TILEDB_UINT16) {
+    uint16_t *typed_buffer = reinterpret_cast<uint16_t *>(buffer);
+    buffer = create_buffer(nbytes, &typed_buffer, &nbytes);
+  } else if (attribute_type == TILEDB_UINT32) {
+    uint32_t *typed_buffer = reinterpret_cast<uint32_t *>(buffer);
+    buffer = create_buffer(nbytes, &typed_buffer, &nbytes);
+  } else if (attribute_type == TILEDB_UINT64) {
+    uint64_t *typed_buffer = reinterpret_cast<uint64_t *>(buffer);
+    buffer = create_buffer(nbytes, &typed_buffer, &nbytes);
+  } else if (attribute_type == TILEDB_FLOAT32) {
+    float *typed_buffer = reinterpret_cast<float *>(buffer);
+    buffer = create_buffer(nbytes, &typed_buffer, &nbytes);
+  } else if (attribute_type == TILEDB_FLOAT64) {
+    double *typed_buffer = reinterpret_cast<double *>(buffer);
+    buffer = create_buffer(nbytes, &typed_buffer, &nbytes);
+  }
+
+  CHECK(buffer != nullptr);
+  
+  std::vector<void *> buffers;
+  std::vector<size_t> buffer_sizes;
+  buffers.push_back(buffer);
+  buffer_sizes.push_back(nbytes);
+
+  buffers.push_back(buffer_coords);
+  buffer_sizes.push_back(buffer_coords_size);
+
+  return 0;
+  
+  // Intialize array
+  TileDB_Array* tiledb_array;
+  rc = tiledb_array_init(
+           tiledb_ctx_,
+           &tiledb_array,
+           array_name_.c_str(),
+           TILEDB_ARRAY_WRITE,
+           NULL,
+           NULL,
+           0);   
+  if(rc != TILEDB_OK)
+    return TILEDB_ERR;
+
+  // Write array
+  rc = tiledb_array_write(tiledb_array, const_cast<const void **>(buffers.data()), buffer_sizes.data());
+  if(rc != TILEDB_OK)
+    return TILEDB_ERR;
+
+  // Finalize the array
+  rc = tiledb_array_finalize(tiledb_array);
+  if(rc != TILEDB_OK)
+    return TILEDB_ERR;
+
+  // Clear buffer
+  if (attribute_type == TILEDB_CHAR) { 
+    clear_buffer(domain_size, reinterpret_cast<char *>(buffer));
+  } else if (attribute_type == TILEDB_INT8) {
+    clear_buffer(domain_size, reinterpret_cast<int8_t *>(buffer));
+  } else if (attribute_type == TILEDB_INT16) {
+    clear_buffer(domain_size, reinterpret_cast<int16_t *>(buffer));
+  } else if (attribute_type == TILEDB_INT32) {
+    clear_buffer(domain_size, reinterpret_cast<int32_t *>(buffer));
+  } else if (attribute_type == TILEDB_INT64) {
+    clear_buffer(domain_size, reinterpret_cast<int64_t *>(buffer));
+  } else if (attribute_type == TILEDB_UINT8) {
+    clear_buffer(domain_size, reinterpret_cast<uint8_t *>(buffer));
+  } else if (attribute_type == TILEDB_UINT16) {
+    clear_buffer(domain_size, reinterpret_cast<uint16_t *>(buffer));
+  } else if (attribute_type == TILEDB_UINT32) {
+    clear_buffer(domain_size, reinterpret_cast<uint32_t *>(buffer));
+  } else if (attribute_type == TILEDB_UINT64) {
+    clear_buffer(domain_size, reinterpret_cast<uint64_t *>(buffer));
+  } else if (attribute_type == TILEDB_FLOAT32) {
+    clear_buffer(domain_size, reinterpret_cast<float *>(buffer));
+  } else if (attribute_type == TILEDB_FLOAT64) {
+    clear_buffer(domain_size, reinterpret_cast<double *>(buffer));
+  }
+
+  // Read array
+  rc = tiledb_array_init(
+           tiledb_ctx_,
+           &tiledb_array,
+           array_name_.c_str(),
+           TILEDB_ARRAY_READ,
+           NULL,
+           NULL,
+           0);   
+  if(rc != TILEDB_OK)
+    return TILEDB_ERR;
+
+  rc = tiledb_array_read(tiledb_array, buffers.data(), buffer_sizes.data());
+  if(rc != TILEDB_OK)
+    return TILEDB_ERR;
+
+  // Finalize the array
+  rc = tiledb_array_finalize(tiledb_array);
+  if(rc != TILEDB_OK)
+    return TILEDB_ERR;
+
+  // Check buffer
+  if (attribute_type == TILEDB_CHAR) {
+    validate_and_cleanup_buffer(domain_size, reinterpret_cast<char *>(buffer));
+  } else if (attribute_type == TILEDB_INT8) {
+    validate_and_cleanup_buffer(domain_size, reinterpret_cast<int8_t *>(buffer));
+  } else if (attribute_type == TILEDB_INT16) {
+    validate_and_cleanup_buffer(domain_size, reinterpret_cast<int16_t *>(buffer));
+  } else if (attribute_type == TILEDB_INT32) {
+    validate_and_cleanup_buffer(domain_size, reinterpret_cast<int32_t *>(buffer));
+  } else if (attribute_type == TILEDB_INT64) {
+    validate_and_cleanup_buffer(domain_size, reinterpret_cast<int64_t *>(buffer));
+  } else if (attribute_type == TILEDB_UINT8) {
+    validate_and_cleanup_buffer(domain_size, reinterpret_cast<uint8_t *>(buffer));
+  } else if (attribute_type == TILEDB_UINT16) {
+    validate_and_cleanup_buffer(domain_size, reinterpret_cast<uint16_t *>(buffer));
+  } else if (attribute_type == TILEDB_UINT32) {
+    validate_and_cleanup_buffer(domain_size, reinterpret_cast<uint32_t *>(buffer));
+  } else if (attribute_type == TILEDB_UINT64) {
+    validate_and_cleanup_buffer(domain_size, reinterpret_cast<uint64_t *>(buffer)); 
+  } else if (attribute_type == TILEDB_FLOAT32) {
+    validate_and_cleanup_buffer(domain_size, reinterpret_cast<float *>(buffer));
+  } else if (attribute_type == TILEDB_FLOAT64) {
+    validate_and_cleanup_buffer(domain_size, reinterpret_cast<double *>(buffer));
+  } 
+  
+  return TILEDB_OK;
+}
+
 int SparseArrayTestFixture::create_sparse_array_2D(
     const int64_t tile_extent_0,
     const int64_t tile_extent_1,
@@ -261,7 +491,53 @@ int SparseArrayTestFixture::write_sparse_array_unsorted_2D(
   return TILEDB_OK;
 } 
 
+TEST_CASE_METHOD(SparseArrayTestFixture, "Test sparse write with attribute types", "[test_sparse_1D_array]") {
+  int rc;
 
+  set_array_name("sparse_test_char_100x100");
+  rc = create_sparse_array_1D(TILEDB_CHAR, 10, 0, 99, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+  CHECK_RC(rc, TILEDB_OK);
+  
+  set_array_name("sparse_test_int8_100x100");
+  rc = create_sparse_array_1D(TILEDB_INT8, 20, 0, 99, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+  CHECK_RC(rc, TILEDB_OK);
+
+  set_array_name("sparse_test_int16_100x100");
+  rc = create_sparse_array_1D(TILEDB_INT16, 30, 0, 99, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+  CHECK_RC(rc, TILEDB_OK);
+
+  set_array_name("sparse_test_int32_100x100");
+  rc = create_sparse_array_1D(TILEDB_INT32, 40, 0, 99, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+  CHECK_RC(rc, TILEDB_OK);
+
+  set_array_name("sparse_test_int64_100x100");
+  rc = create_sparse_array_1D(TILEDB_INT64, 50, 0, 99, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+  CHECK_RC(rc, TILEDB_OK);
+
+  set_array_name("sparse_test_uint8_100x100");
+  rc = create_sparse_array_1D(TILEDB_UINT8, 60, 0, 99, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+  CHECK_RC(rc, TILEDB_OK);
+
+  set_array_name("sparse_test_uint16_100x100");
+  rc = create_sparse_array_1D(TILEDB_UINT16, 70, 0, 99, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+  CHECK_RC(rc, TILEDB_OK);
+
+  set_array_name("sparse_test_uint32_100x100");
+  rc = create_sparse_array_1D(TILEDB_UINT32, 80, 0, 99, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+  CHECK_RC(rc, TILEDB_OK);
+
+  set_array_name("sparse_test_uint64_100x100");
+  rc = create_sparse_array_1D(TILEDB_UINT64, 10, 0, 99, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+  CHECK_RC(rc, TILEDB_OK);
+
+  set_array_name("sparse_test_float32_100x100");
+  rc = create_sparse_array_1D(TILEDB_FLOAT32, 10, 0, 99, TILEDB_COL_MAJOR, TILEDB_ROW_MAJOR);
+  CHECK_RC(rc, TILEDB_OK);
+
+  set_array_name("sparse_test_float64_100x100");
+  rc = create_sparse_array_1D(TILEDB_FLOAT64, 10, 0, 99, TILEDB_COL_MAJOR, TILEDB_COL_MAJOR);
+  CHECK_RC(rc, TILEDB_OK);
+}
 
 /**
  * Test is to randomly read subregions of the array and

--- a/test/src/c_api/test_sparse_array_api.cc
+++ b/test/src/c_api/test_sparse_array_api.cc
@@ -154,10 +154,11 @@ int SparseArrayTestFixture::create_sparse_array_1D(
   size_t nbytes = domain_size/10;
 
   int32_t* buffer_coords = new int32_t[nbytes];
-  for (int32_t i = 0; i < nbytes; ++i) {
+  for (int32_t i = 0; i < domain_size/10; ++i) {
     buffer_coords[i] = i;
   }
   size_t buffer_coords_size = nbytes * sizeof(int32_t);
+  create_buffer(nbytes, &buffer_coords, &nbytes);
   
   void *buffer = nullptr;
   if (attribute_type == TILEDB_CHAR) {

--- a/test/src/misc/test_utils.cc
+++ b/test/src/misc/test_utils.cc
@@ -571,6 +571,35 @@ TEST_CASE("Test utils file system operations", "[test_utils_fs]") {
   free(temp_dir);
 }
 
+TEST_CASE("Test empty value concept", "[empty_cell_val]") {
+  char char_max = get_tiledb_empty_value<char>();
+  CHECK(char_max == CHAR_MAX);
+
+  int8_t int8_max =  get_tiledb_empty_value<int8_t>();
+  CHECK(int8_max == INT8_MAX);
+  int16_t int16_max =  get_tiledb_empty_value<int16_t>();
+  CHECK(int16_max == INT16_MAX);
+  int32_t int32_max =  get_tiledb_empty_value<int32_t>();
+  CHECK(int32_max == INT32_MAX);
+  int64_t int64_max =  get_tiledb_empty_value<int64_t>();
+  CHECK(int64_max == INT64_MAX);
+
+  uint64_t uint8_max =  get_tiledb_empty_value<uint8_t>();
+  CHECK(uint8_max == UINT8_MAX);
+  uint16_t uint16_max =  get_tiledb_empty_value<uint16_t>();
+  CHECK(uint16_max == UINT16_MAX);
+  uint32_t uint32_max =  get_tiledb_empty_value<uint32_t>();
+  CHECK(uint32_max == UINT32_MAX);
+  uint64_t uint64_max =  get_tiledb_empty_value<uint64_t>();
+  CHECK(uint64_max == UINT64_MAX);
+
+  float float_max =  get_tiledb_empty_value<float>();
+  CHECK(float_max == FLT_MAX);
+  double double_max =  get_tiledb_empty_value<double>();
+  CHECK(double_max == DBL_MAX);
+
+}
+
 TEST_CASE("Test storage URLs", "[storage_urls]") {
   CHECK(!is_supported_cloud_path("gibberish://ddd/d"));
 


### PR DESCRIPTION
Add support with unit tests for signed and unsigned int 8/16/32/64 in addition to what is already present in TileDB. 