### PR TITLE
Initial support for pre and post compression filters with delta encoding.

### DIFF
--- a/core/include/array/array_schema.h
+++ b/core/include/array/array_schema.h
@@ -82,6 +82,15 @@
 /** Stores potential error messages. */
 extern std::string tiledb_as_errmsg;
 
+/** Compression fields are stored as 1 byte in the schema, the last 4 least significant digits
+  * denote the main compression type, the next 2 denote pre compression filters and the leading 2 digits
+  * denote the post compression filters.
+  * Compression fields can be simply composed as a sum of 1 main compression type and optionally one pre
+  * and one post compression type.
+  * e.g. compression for an attribute could be TILEDB_GZIP+TILEDB_DELTA_ENCODE+TILEDB_CHECKSUM
+  *                                                            ^^^^pre^^^^      ^^^^post^^^^
+  */
+typedef enum filter_type_t {COMPRESS=0xF, PRE_COMPRESS=0x30, POST_COMPRESS=0xC0} filter_type_t;
 
 /** Specifies the array schema. */
 class ArraySchema {

--- a/core/include/c_api/tiledb_constants.h
+++ b/core/include/c_api/tiledb_constants.h
@@ -144,7 +144,7 @@
 /**@}*/
 
 /**@{*/
-/** Compression type. */
+/** Compression type. Range from 0-15 */
 #define TILEDB_NO_COMPRESSION                        0
 #define TILEDB_GZIP                                  1
 #define TILEDB_ZSTD                                  2
@@ -156,6 +156,17 @@
 #define TILEDB_BLOSC_ZLIB                            8
 #define TILEDB_BLOSC_ZSTD                            9
 #define TILEDB_RLE                                  10
+/**@}*/
+
+/**@{*/
+/** Pre compression filter defines. Range from 16-23 */
+#define TILEDB_DELTA_ENCODE                         16
+#define TILEDB_BYTE_SHUFFLE                         17
+/**@}*/
+
+/**@{*/
+/** Post compression filter defines. 24-31 */
+#define TILEDB_POST_FILTER_EXAMPLE_UNUSED           24
 /**@}*/
 
 /**@{*/

--- a/core/include/codec/codec.h
+++ b/core/include/codec/codec.h
@@ -34,6 +34,7 @@
 #define __CODEC_H__
 
 #include "array_schema.h"
+#include "codec_filter.h"
 
 #include <errno.h>
 #include <dlfcn.h>
@@ -73,8 +74,6 @@ class Codec {
 
   static int get_default_level(const int compression_type);
 
-  static int normalize_level(const int compression_type, const int compression_level);
-
   static int print_errmsg(const std::string& msg);
   
   /* ********************************* */
@@ -96,6 +95,12 @@ class Codec {
   virtual ~Codec() {
     if(tile_compressed_ != NULL) {
       free(tile_compressed_);
+    }
+    if (pre_compression_filter_) {
+      delete pre_compression_filter_;
+    }
+    if (post_compression_filter_) {
+      delete post_compression_filter_;
     }
   }
   
@@ -165,20 +170,41 @@ class Codec {
   } while (false)
 
   /**
-   * @return TILEDB_CD_OK on success and TILEDB_CD_ERR on error.
    */
-  virtual int compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) = 0;
+  const std::string& name() {
+    return name_;
+  }
+
+  int compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size);
+
+  int decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size);
 
   /**
    * @return TILEDB_CD_OK on success and TILEDB_CD_ERR on error.
    */
-  virtual int decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) = 0;
+  virtual int do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) = 0;
+
+  /**
+   * @return TILEDB_CD_OK on success and TILEDB_CD_ERR on error.
+   */
+  virtual int do_decompress_tile(unsigned char* tile_compressed, size_t tile_compressed_size, unsigned char* tile, size_t tile_size) = 0;
+
+  void set_pre_compression(CodecFilter* filter) {
+    pre_compression_filter_ = filter;
+  };
+
+  void set_post_compression(CodecFilter* filter) {
+    post_compression_filter_ = filter;
+  };
 
   /* ********************************* */
   /*         PROTECTED ATTRIBUTES      */
   /* ********************************* */
  protected:
+  std::string name_ = "";
   int compression_level_;
+  CodecFilter* pre_compression_filter_ = NULL;
+  CodecFilter* post_compression_filter_ = NULL;
 
   /** Internal buffer used in the case of compression. */
   void* tile_compressed_ = NULL;

--- a/core/include/codec/codec.h
+++ b/core/include/codec/codec.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/include/codec/codec_blosc.h
+++ b/core/include/codec/codec_blosc.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -86,9 +86,9 @@ class CodecBlosc : public Codec {
     }
   }
   
-  int compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size);
+  int do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) override;
 
-  int decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size);
+  int do_decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) override;
 
  private:
   std::string compressor_;

--- a/core/include/codec/codec_filter.h
+++ b/core/include/codec/codec_filter.h
@@ -1,0 +1,118 @@
+/**
+ * @file   codec_filter.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * @section DESCRIPTION
+ *
+ * This file defines the base class for pre and post compression filters
+ */
+
+#ifndef __CODEC_FILTER_H__
+#define __CODEC_FILTER_H__
+
+#include <iostream>
+#include <string>
+
+/* ********************************* */
+/*             CONSTANTS             */
+/* ********************************* */
+
+/**@{*/
+/** Return code. */
+#define TILEDB_CDF_OK        0
+#define TILEDB_CDF_ERR      -1
+/**@}*/
+
+/* ****************************** */
+/*             MACROS             */
+/* ****************************** */
+
+/** Default error message. */
+#define TILEDB_CDF_ERRMSG std::string("[TileDB::CodecFilter] Error: ")
+
+class CodecFilter {
+ public:
+   /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /**
+   * Constructor. 
+   *
+   * @param compression_level
+   */
+  CodecFilter(int filter_stride=1, bool filter_in_place=true) {
+    assert(filter_stride > 0);
+    filter_stride_ = filter_stride;
+    filter_in_place_ = filter_in_place;
+  }
+  
+  virtual ~CodecFilter() {
+    free(filter_buffer_);
+  }
+
+  /**
+   */
+  const std::string& name() {
+    return filter_name_;
+  }
+
+  const bool in_place() {
+    return filter_in_place_;
+  }
+
+  const int stride() {
+    return filter_stride_;
+  }
+
+  virtual int code(unsigned char* tile, size_t tile_size, unsigned char* tile_coded, size_t& tile_coded_size) {
+    return print_errmsg("virtual method should be overridden");
+  }
+
+  virtual int code(unsigned char *tile, size_t tile_size) {
+    return print_errmsg("virtual method should be overridden");
+  }
+
+  virtual int decode(unsigned char* tile_coded,  size_t tile_coded_size, void** tile, size_t& tile_size) {
+    return print_errmsg("virtual method should be overridden");
+  }
+
+  virtual int decode(unsigned char* tile_coded, size_t tile_coded_size) {
+    return print_errmsg("virtual method should be overridden");
+  }
+
+  int print_errmsg(const std::string& msg);
+
+ protected:
+  std::string filter_name_ = "";
+  bool filter_in_place_;
+  int filter_stride_;
+
+  /** Internal buffer malloc'ed if necessary */
+  void* filter_buffer_ = NULL;
+};
+
+#endif /* __CODEC_FILTER_H_ */

--- a/core/include/codec/codec_filter.h
+++ b/core/include/codec/codec_filter.h
@@ -72,7 +72,9 @@ class CodecFilter {
   }
   
   virtual ~CodecFilter() {
-    free(filter_buffer_);
+    if (filter_buffer_ != NULL) {
+      free(filter_buffer_);
+    }
   }
 
   /**

--- a/core/include/codec/codec_filter.h
+++ b/core/include/codec/codec_filter.h
@@ -33,6 +33,7 @@
 #ifndef __CODEC_FILTER_H__
 #define __CODEC_FILTER_H__
 
+#include <cassert>
 #include <iostream>
 #include <string>
 

--- a/core/include/codec/codec_filter_delta_encode.h
+++ b/core/include/codec/codec_filter_delta_encode.h
@@ -40,7 +40,7 @@ class CodecDeltaEncode : public CodecFilter {
  public:
   using CodecFilter::CodecFilter;
 
-  CodecDeltaEncode(int type=TILEDB_UINT64, int filter_stride=1): CodecFilter(filter_stride) {
+  CodecDeltaEncode(int type=TILEDB_UINT64, int filter_stride=1): CodecFilter(filter_stride, true) {
     filter_name_ = "Delta Encoding";
     type_ = type;
   }

--- a/core/include/codec/codec_filter_delta_encode.h
+++ b/core/include/codec/codec_filter_delta_encode.h
@@ -1,11 +1,11 @@
 /**
- * @file codec_gzip.h
+ * @file   codec_filter_delta_encode.h
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,23 +27,41 @@
  * 
  * @section DESCRIPTION
  *
- * CodecGzip derived from Codec for gzip support
- *
+ * This file defines the Delta Encoder Pre-Compression Filter
  */
 
-#ifndef __CODEC_GZIP_H__
-#define  __CODEC_GZIP_H__
+#ifndef __CODEC_DELTA_ENCODING_H__
+#define  __CODEC_DELTA_ENCODING_H__
 
-#include "codec.h"
+#include "codec_filter.h"
+#include "tiledb_constants.h"
 
-class CodecGzip : public Codec {
+class CodecDeltaEncode : public CodecFilter {
  public:
-  using Codec::Codec;
-  
-  int do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) override;
+  using CodecFilter::CodecFilter;
 
-  int do_decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) override;
+  CodecDeltaEncode(int type=TILEDB_UINT64, int filter_stride=1): CodecFilter(filter_stride) {
+    filter_name_ = "Delta Encoding";
+    type_ = type;
+  }
+
+  int type() {
+    return type_;
+  }
+      
+  /**
+   * @return TILEDB_CD_OK on success and TILEDB_CD_ERR on error.
+   */
+  int code(unsigned char* tile, size_t tile_size) override;
+
+  /**
+   * @return TILEDB_CD_OK on success and TILEDB_CD_ERR on error.
+   */
+  int decode(unsigned char* tile_coded,  size_t tile_coded_size) override;
+
+ private:
+  int type_;
   
 };
 
-#endif /*__CODEC_GZIP_H__*/
+#endif /*  __CODEC_DELTA_ENCODING_H__ */

--- a/core/include/codec/codec_gzip.h
+++ b/core/include/codec/codec_gzip.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/include/codec/codec_lz4.h
+++ b/core/include/codec/codec_lz4.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -79,9 +79,9 @@ class CodecLZ4 : public Codec {
     }
   }
   
-  int compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size);
+  int do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) override;
 
-  int decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size);
+  int do_decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) override;
   
 };
 

--- a/core/include/codec/codec_rle.h
+++ b/core/include/codec/codec_rle.h
@@ -46,9 +46,9 @@ class CodecRLE : public Codec {
     value_size_ = value_size;
   }
   
-  int compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size);
+  int do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) override;
 
-  int decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size);
+  int do_decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) override;
 
  private:
   int attribute_num_;

--- a/core/include/codec/codec_rle.h
+++ b/core/include/codec/codec_rle.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/include/codec/codec_zstd.h
+++ b/core/include/codec/codec_zstd.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -83,9 +83,9 @@ class CodecZStandard : public Codec {
      }
   }
   
-  int compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size);
+  int do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) override;
 
-  int decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size);
+  int do_decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) override;
   
 };
 

--- a/core/src/codec/codec.cc
+++ b/core/src/codec/codec.cc
@@ -179,7 +179,7 @@ Codec* Codec::create(const ArraySchema* array_schema, const int attribute_id, co
     case 0:
       break;
     default:
-      std::cerr << "Unsupported pre-compression filter: " << post_compress_type << "\n";
+      std::cerr << "Unsupported post-compression filter: " << post_compress_type << "\n";
   }
 
   return codec;

--- a/core/src/codec/codec.cc
+++ b/core/src/codec/codec.cc
@@ -42,6 +42,8 @@
 #  include "codec_blosc.h"
 #endif
 #include "codec_rle.h"
+#include "codec_filter.h"
+#include "codec_filter_delta_encode.h"
 #include "tiledb.h"
 
 /* ****************************** */
@@ -86,38 +88,42 @@ static std::string get_blosc_compressor(const int compression_type) {
 }
 #endif
 
+int get_filter_type(const ArraySchema* array_schema, const int attribute_id,
+                         const bool is_offsets_compression, filter_type_t filter_type) {
+  if (is_offsets_compression) {
+    return array_schema->offsets_compression(attribute_id) & filter_type;
+  } else {
+    return array_schema->compression(attribute_id) & filter_type;
+  }
+}
+
 Codec* Codec::create(const ArraySchema* array_schema, const int attribute_id, const bool is_offsets_compression) {
-  int compression_type;
-  if (is_offsets_compression) {
-    compression_type = array_schema->offsets_compression(attribute_id);
-  } else {
-    compression_type = array_schema->compression(attribute_id);
-  }
-  int compression_level;
-  if (is_offsets_compression) {
-    compression_level = array_schema->offsets_compression_level(attribute_id);
-  } else {
-    compression_level = array_schema->compression_level(attribute_id);
-  }
+  int compression_type = get_filter_type(array_schema, attribute_id, is_offsets_compression, COMPRESS);
+  int compression_level = array_schema->compression_level(attribute_id);
+
   size_t type_size;
   if (is_offsets_compression) {
     type_size = sizeof(size_t);
   } else {
     type_size = array_schema->type_size(attribute_id);
   }
-  
+
+  Codec* codec = NULL;
   switch (compression_type) {
   case TILEDB_NO_COMPRESSION:
     return NULL;
   case TILEDB_GZIP:
-    return new CodecGzip(compression_level);
+    codec = new CodecGzip(compression_level);
+    break;
 #ifdef ENABLE_ZSTD
   case TILEDB_ZSTD:
-    return new CodecZStandard(compression_level);
+    codec = new CodecZStandard(compression_level);
+    break;
 #endif
 #ifdef ENABLE_LZ4
   case TILEDB_LZ4:
-    return new CodecLZ4(compression_level);
+    codec = new CodecLZ4(compression_level);
+    break;
 #endif
 #ifdef ENABLE_BLOSC
   case TILEDB_BLOSC:
@@ -126,7 +132,8 @@ Codec* Codec::create(const ArraySchema* array_schema, const int attribute_id, co
   case TILEDB_BLOSC_SNAPPY:
   case TILEDB_BLOSC_ZLIB:
   case TILEDB_BLOSC_ZSTD: {
-    return new CodecBlosc(compression_level, get_blosc_compressor(compression_type), type_size);
+    codec = new CodecBlosc(compression_level, get_blosc_compressor(compression_type), type_size);
+    break;
   }
 #endif
   case TILEDB_RLE: {
@@ -139,13 +146,43 @@ Codec* Codec::create(const ArraySchema* array_schema, const int attribute_id, co
       (array_schema->var_size(attribute_id) || is_coords) ? 
       array_schema->type_size(attribute_id) :
       array_schema->cell_size(attribute_id);
-    return new CodecRLE(attribute_num, dim_num, cell_order, is_coords, value_size);
+    codec = new CodecRLE(attribute_num, dim_num, cell_order, is_coords, value_size);
+    break;
   }
   default:
     // TODO throw exception
     std::cerr << "Unsupported compression type:" << compression_type << "\n";
     return NULL;
   }
+
+  int pre_compress_type = get_filter_type(array_schema, attribute_id, is_offsets_compression, PRE_COMPRESS);
+  switch (pre_compress_type) {
+    case 0:
+      break;
+    case TILEDB_DELTA_ENCODE:
+      CodecFilter* filter;
+      if (array_schema->attribute(attribute_id) == TILEDB_COORDS) {
+        filter = new CodecDeltaEncode(array_schema->type(attribute_id), array_schema->dim_num());
+      } else if (is_offsets_compression) {
+        filter = new CodecDeltaEncode(TILEDB_UINT64, 1);
+      } else {
+        filter = new CodecDeltaEncode(array_schema->type(attribute_id), array_schema->cell_val_num(attribute_id));
+      }
+      codec->set_pre_compression(filter);
+      break;
+    default:
+      std::cerr << "Unsupported pre-compression filter: " << pre_compress_type << "\n";
+  }
+
+  int post_compress_type = get_filter_type(array_schema, attribute_id, is_offsets_compression, POST_COMPRESS);
+  switch (post_compress_type) {
+    case 0:
+      break;
+    default:
+      std::cerr << "Unsupported pre-compression filter: " << post_compress_type << "\n";
+  }
+
+  return codec;
 }
 
 int Codec::get_default_level(int compression_type) {
@@ -161,22 +198,36 @@ int Codec::get_default_level(int compression_type) {
   }
 }
 
-int Codec::normalize_level(const int compression_type, const int compression_level) {
-  switch (compression_type) {
-    case TILEDB_GZIP:
-      if (compression_level < Z_DEFAULT_COMPRESSION || compression_level > Z_BEST_COMPRESSION) {
-	 return Z_DEFAULT_COMPRESSION;
-      }
-  default:
-    // TODO: Implement normalize compression levels in the individual codecs.
-    return compression_level;
-  }
-}
-
 int Codec::print_errmsg(const std::string& msg) {
   if (msg.length() > 0) {
     PRINT_ERROR(msg);
     tiledb_cd_errmsg = TILEDB_CD_ERRMSG + msg;
   }
   return TILEDB_CD_ERR;
+}
+
+int Codec::compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
+  if (pre_compression_filter_ && pre_compression_filter_->in_place()) {
+    if (pre_compression_filter_->code(tile, tile_size) != 0) {
+      return print_errmsg("Could not apply filter " + pre_compression_filter_->name() + " before compressing");
+    }
+  }
+    
+  if (do_compress_tile(tile, tile_size, tile_compressed, tile_compressed_size)) {
+    return print_errmsg("Could not compress with " + name());
+  }
+  
+  return TILEDB_CD_OK;
+}
+
+int Codec::decompress_tile(unsigned char* tile_compressed, size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
+  if (do_decompress_tile(tile_compressed, tile_compressed_size, tile, tile_size)) {
+    return print_errmsg("Could not compress with " + name());
+  }
+  if (pre_compression_filter_ && pre_compression_filter_->in_place()) {
+    if (pre_compression_filter_->decode(tile, tile_size) != 0) {
+      return print_errmsg("Could not apply filter " + pre_compression_filter_->name() + " after decompressing");
+    }
+  }
+  return TILEDB_CD_OK;
 }

--- a/core/src/codec/codec.cc
+++ b/core/src/codec/codec.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/codec/codec_blosc.cc
+++ b/core/src/codec/codec_blosc.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,7 @@
 #define BLOSC_EXTERN_DECL extern
 #include "codec_blosc.h"
 
-int CodecBlosc::compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
+int CodecBlosc::do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
   // Allocate space to store the compressed tile
 #define BLOSC_MAX_OVERHEAD 16
   size_t compress_bound = tile_size + BLOSC_MAX_OVERHEAD;
@@ -85,7 +85,7 @@ int CodecBlosc::compress_tile(unsigned char* tile, size_t tile_size, void** tile
   return TILEDB_CD_OK;
 }
 
-int CodecBlosc::decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
+int CodecBlosc::do_decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
   // Initialization
   blosc_init();
 

--- a/core/src/codec/codec_filter.cc
+++ b/core/src/codec/codec_filter.cc
@@ -1,11 +1,11 @@
 /**
- * @file codec_gzip.h
+ * @file   codec_filter.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,23 +27,33 @@
  * 
  * @section DESCRIPTION
  *
- * CodecGzip derived from Codec for gzip support
- *
+ * This file implements the base class for pre and post compression filters
  */
 
-#ifndef __CODEC_GZIP_H__
-#define  __CODEC_GZIP_H__
+#include "codec_filter.h"
+#include <iostream>
+#include <string>
 
-#include "codec.h"
+/* ****************************** */
+/*             MACROS             */
+/* ****************************** */
 
-class CodecGzip : public Codec {
- public:
-  using Codec::Codec;
-  
-  int do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) override;
+#ifdef TILEDB_VERBOSE
+#  define PRINT_ERROR(x) std::cerr << TILEDB_CDF_ERRMSG << x << ".\n" 
+#else
+#  define PRINT_ERROR(x) do { } while(0) 
+#endif
 
-  int do_decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) override;
-  
-};
+/* ****************************** */
+/*        GLOBAL VARIABLES        */
+/* ****************************** */
 
-#endif /*__CODEC_GZIP_H__*/
+std::string tiledb_cdf_errmsg = "";
+
+int CodecFilter::print_errmsg(const std::string& msg) {
+  if (msg.length() > 0) {
+    PRINT_ERROR(msg);
+    tiledb_cdf_errmsg = TILEDB_CDF_ERRMSG + msg;
+  }
+  return TILEDB_CDF_ERR;
+}

--- a/core/src/codec/codec_filter_delta_encode.cc
+++ b/core/src/codec/codec_filter_delta_encode.cc
@@ -1,0 +1,104 @@
+/**
+ * @file   codec_filter_delta_encode.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * @section DESCRIPTION
+ *
+ * This file implements the Delta Encoder Pre-Compression Filter.
+ */
+
+#include "codec_filter_delta_encode.h"
+#include "tiledb_constants.h"
+
+#include <vector>
+
+template<typename T>
+int do_code(T* tile, size_t tile_size_in_bytes, CodecFilter* filter) {
+  int stride = filter->stride();
+  size_t length = tile_size_in_bytes/sizeof(T)/stride;
+  if (tile_size_in_bytes/sizeof(T)%stride != 0) {
+    return filter->print_errmsg("Only tiles that are divisible by stride supported");
+  }
+  std::vector<T> last(stride, 0);
+  for (T i=0; i<length; i++) {
+    for (int j=0; j<stride; j++) {
+      T index = i*stride+j;
+      T current = tile[index];
+      tile[index] = current - last[j];
+      last[j] = current;
+    }
+  }
+  return TILEDB_CDF_OK;
+}
+
+int CodecDeltaEncode::code(unsigned char* tile, size_t tile_size) {
+  switch (type_) {
+    case TILEDB_INT32:
+      return do_code(reinterpret_cast<int32_t *>(tile), tile_size, this);
+    case TILEDB_INT64:
+      return do_code(reinterpret_cast<int64_t *>(tile), tile_size, this);
+    case TILEDB_UINT32:
+      return do_code(reinterpret_cast<uint32_t *>(tile), tile_size, this);
+    case TILEDB_UINT64:
+      return do_code(reinterpret_cast<uint64_t *>(tile), tile_size, this);
+    default:
+      return print_errmsg("CodecDeltaEncode not implemented for type");
+  }
+}
+
+template<typename T>
+int do_decode(T* tile, size_t tile_size_in_bytes, CodecFilter* filter) {
+  int stride = filter->stride();
+  size_t length = tile_size_in_bytes/sizeof(T)/stride;
+  if (tile_size_in_bytes/sizeof(T)%stride != 0) {
+    return filter->print_errmsg("Only tiles that are divisible by stride supported");
+  }
+  std::vector<T> last(stride, 0);
+  for (int i = 0; i < length; i++) {
+    for (int j=0; j<stride; j++) {
+      T index = i*stride+j;
+      T delta = tile[index];
+      tile[index] = delta + last[j];
+      last[j] = tile[index];
+    }
+  }
+  return TILEDB_CDF_OK;
+}
+
+int CodecDeltaEncode::decode(unsigned char* tile, size_t tile_size) {
+  switch (type_) {
+    case TILEDB_INT32:
+      return do_decode(reinterpret_cast<int32_t *>(tile), tile_size, this);
+    case TILEDB_INT64:
+      return do_decode(reinterpret_cast<int64_t *>(tile), tile_size, this);
+    case TILEDB_UINT32:
+      return do_decode(reinterpret_cast<uint32_t *>(tile), tile_size, this);
+    case TILEDB_UINT64:
+      return do_decode(reinterpret_cast<uint64_t *>(tile), tile_size, this);
+    default:
+      return print_errmsg("CodecDeltaEncode not implemented for type");
+  }
+}

--- a/core/src/codec/codec_filter_delta_encode.cc
+++ b/core/src/codec/codec_filter_delta_encode.cc
@@ -43,9 +43,9 @@ int do_code(T* tile, size_t tile_size_in_bytes, CodecFilter* filter) {
     return filter->print_errmsg("Only tiles that are divisible by stride supported");
   }
   std::vector<T> last(stride, 0);
-  for (T i=0; i<length; i++) {
+  for (size_t i=0; i<length; i++) {
     for (int j=0; j<stride; j++) {
-      T index = i*stride+j;
+      size_t index = i*stride+j;
       T current = tile[index];
       tile[index] = current - last[j];
       last[j] = current;
@@ -77,9 +77,9 @@ int do_decode(T* tile, size_t tile_size_in_bytes, CodecFilter* filter) {
     return filter->print_errmsg("Only tiles that are divisible by stride supported");
   }
   std::vector<T> last(stride, 0);
-  for (int i = 0; i < length; i++) {
+  for (size_t i = 0; i < length; i++) {
     for (int j=0; j<stride; j++) {
-      T index = i*stride+j;
+      size_t index = i*stride+j;
       T delta = tile[index];
       tile[index] = delta + last[j];
       last[j] = tile[index];

--- a/core/src/codec/codec_gzip.cc
+++ b/core/src/codec/codec_gzip.cc
@@ -35,7 +35,7 @@
 
 #include <math.h>
 
-int CodecGzip::compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
+int CodecGzip::do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
   // Allocate space to store the compressed tile
   if(tile_compressed_ == NULL) {
     tile_compressed_allocated_size_ = 
@@ -67,7 +67,7 @@ int CodecGzip::compress_tile(unsigned char* tile, size_t tile_size, void** tile_
   return TILEDB_CD_OK;
 }
 
-int CodecGzip::decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
+int CodecGzip::do_decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
   // Decompress tile 
   size_t gunzip_out_size;
   if(gunzip(

--- a/core/src/codec/codec_lz4.cc
+++ b/core/src/codec/codec_lz4.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,7 @@
 #define LZ4_EXTERN_DECL extern
 #include "codec_lz4.h"
 
-int CodecLZ4::compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
+int CodecLZ4::do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
     // Allocate space to store the compressed tile
   size_t compress_bound = LZ4_compressBound(tile_size);
   if(tile_compressed_ == NULL) {
@@ -66,7 +66,7 @@ int CodecLZ4::compress_tile(unsigned char* tile, size_t tile_size, void** tile_c
   return TILEDB_CD_OK;
 }
 
-int CodecLZ4::decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
+int CodecLZ4::do_decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
     // Decompress tile 
   if(LZ4_decompress_safe(
          (const char*) tile_compressed, 

--- a/core/src/codec/codec_rle.cc
+++ b/core/src/codec/codec_rle.cc
@@ -33,7 +33,7 @@
 #include "codec_rle.h"
 #include "utils.h"
 
-int CodecRLE::compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
+int CodecRLE::do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
   // Allocate space to store the compressed tile
   size_t compress_bound;
   if(!is_coords_)
@@ -96,7 +96,7 @@ int CodecRLE::compress_tile(unsigned char* tile, size_t tile_size, void** tile_c
   return TILEDB_CD_OK;
 }
 
-int CodecRLE::decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
+int CodecRLE::do_decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
    // Decompress tile
   int rc;
   if(!is_coords_) { 

--- a/core/src/codec/codec_rle.cc
+++ b/core/src/codec/codec_rle.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/codec/codec_zstd.cc
+++ b/core/src/codec/codec_zstd.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,7 @@
 #define ZSTD_EXTERN_DECL extern
 #include "codec_zstd.h"
 
-int CodecZStandard::compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
+int CodecZStandard::do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
    // Allocate space to store the compressed tile
   size_t compress_bound = ZSTD_compressBound(tile_size);
   if(tile_compressed_ == NULL) {
@@ -68,7 +68,7 @@ int CodecZStandard::compress_tile(unsigned char* tile, size_t tile_size, void** 
   return TILEDB_CD_OK;
 }
 
-int CodecZStandard::decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
+int CodecZStandard::do_decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
     // Decompress tile 
   size_t zstd_size = 
       ZSTD_decompress(

--- a/examples/src/tiledb_array_create_sparse.cc
+++ b/examples/src/tiledb_array_create_sparse.cc
@@ -69,12 +69,14 @@ int main(int argc, char *argv[]) {
         TILEDB_GZIP,              // a2
 #endif
         TILEDB_NO_COMPRESSION,    // a3
-        TILEDB_NO_COMPRESSION     // coordinates
+        TILEDB_GZIP
+        +TILEDB_DELTA_ENCODE      // coordinates
   };
   const int offsets_compression[] =
   {
         0,                        // a1 - DON'T CARE
-        TILEDB_GZIP,              // a2
+        TILEDB_GZIP
+        +TILEDB_DELTA_ENCODE,     // a2
         0                         // a3 - DON'T CARE
   };
   int64_t tile_extents[] = 

--- a/test/src/codec/test_codec.cc
+++ b/test/src/codec/test_codec.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,10 +40,10 @@
 class TestCodecBasic : public Codec {
  public:
   using Codec::Codec;
-  int compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
+  int do_compress_tile(unsigned char* tile, size_t tile_size, void** tile_compressed, size_t& tile_compressed_size) {
     return TILEDB_CD_OK;
   }
-  int decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
+  int do_decompress_tile(unsigned char* tile_compressed,  size_t tile_compressed_size, unsigned char* tile, size_t tile_size) {
     return TILEDB_CD_OK;
   }
 };

--- a/test/src/codec/test_codec_filter.cc
+++ b/test/src/codec/test_codec_filter.cc
@@ -114,15 +114,15 @@ TEST_CASE("Test delta encoding", "[codec_filter_delta_encoding]") {
   }
   CHECK(codec_filter->decode(reinterpret_cast<unsigned char*>(vector1.data()), 10*sizeof(int64_t)) == TILEDB_CDF_OK);
   for (auto i=0u; i<10; i++) {
-    CHECK(vector1[i] == i+1);
+    CHECK(vector1[i] == (unsigned char)(i+1));
   }
   delete codec_filter;
 
-  codec_filter = new CodecDeltaEncode(TILEDB_INT64);
+  codec_filter = new CodecDeltaEncode(TILEDB_INT64, 1);
   CHECK(codec_filter->type() == TILEDB_INT64);
   delete codec_filter;
 
-  codec_filter = new CodecDeltaEncode(TILEDB_UINT32);
+  codec_filter = new CodecDeltaEncode(TILEDB_UINT32, 1);
   CHECK(codec_filter->type() == TILEDB_UINT32);
   delete codec_filter;
   

--- a/test/src/codec/test_codec_filter.cc
+++ b/test/src/codec/test_codec_filter.cc
@@ -1,0 +1,129 @@
+/**
+ * @file   test_codec_filter.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * @section DESCRIPTION
+ *
+ * Test pre-post compression filters
+ */
+
+#include "catch.h"
+#include "codec_filter_delta_encode.h"
+#include "tiledb_constants.h"
+
+TEST_CASE("Test codec filter basic", "[codec_filter_basic]") {
+  CodecFilter* codec_filter = new CodecFilter();
+  CHECK(codec_filter->stride() == 1);
+  CHECK(codec_filter->in_place());
+  CHECK(codec_filter->name() == "");
+  delete codec_filter;
+
+  codec_filter = new CodecFilter(3);
+  CHECK(codec_filter->stride() == 3);
+  CHECK(codec_filter->in_place());
+  CHECK(codec_filter->name() == "");
+  delete codec_filter;
+
+  codec_filter = new CodecFilter(5, false);
+  CHECK(codec_filter->stride() == 5);
+  CHECK(!codec_filter->in_place());
+  CHECK(codec_filter->name() == "");
+  size_t sz = 0;
+  CHECK(codec_filter->code(NULL, 0, NULL, sz));
+  CHECK(codec_filter->code(NULL, 0));
+  CHECK(codec_filter->decode(NULL, 0, NULL, sz));
+  CHECK(codec_filter->decode(NULL, 0));
+  delete codec_filter;
+}
+
+TEST_CASE("Test delta encoding", "[codec_filter_delta_encoding]") {
+  CodecDeltaEncode* codec_filter = new CodecDeltaEncode();
+  CHECK(codec_filter->name() == "Delta Encoding");
+  CHECK(codec_filter->in_place());
+  CHECK(codec_filter->stride() == 1);
+  CHECK(codec_filter->type() == TILEDB_UINT64);
+
+  // Fill vector with 1's
+  std::vector<uint64_t> vector(10, 1);
+  CHECK(codec_filter->code(reinterpret_cast<unsigned char*>(vector.data()), 10*sizeof(int64_t)) == TILEDB_CDF_OK);
+  CHECK(vector[0] == 1);
+  for (auto i=1u; i<10; i++) {
+    CHECK(vector[i] == 0);
+  }
+  CHECK(codec_filter->decode(reinterpret_cast<unsigned char*>(vector.data()), 10*sizeof(int64_t)) == TILEDB_CDF_OK);
+  for (auto i=0u; i<10; i++) {
+    CHECK(vector[i] == 1); // After decode they should match the original vector
+  }
+
+  // Fill vector with 1,2,3,4...
+  for (auto i=0u; i<10; i++) {
+    vector[i] = i+1;
+  }
+  CHECK(codec_filter->code(reinterpret_cast<unsigned char*>(vector.data()), 10*sizeof(int64_t)) == TILEDB_CDF_OK);
+  for (auto i=0u; i<10; i++) {
+    CHECK(vector[i] == 1);
+  }
+   CHECK(codec_filter->decode(reinterpret_cast<unsigned char*>(vector.data()), 10*sizeof(int64_t)) == TILEDB_CDF_OK);
+  for (auto i=0u; i<10; i++) {
+    CHECK(vector[i] == i+1);
+  }
+  delete codec_filter;
+
+  codec_filter = new CodecDeltaEncode(TILEDB_UINT64, 3);
+  CHECK(codec_filter->type() == TILEDB_UINT64);
+  CHECK(codec_filter->stride() == 3);
+  // This should fail as 10 is not divisible by 3;
+  CHECK(codec_filter->code(reinterpret_cast<unsigned char*>(vector.data()), 10*sizeof(int64_t)) == TILEDB_CDF_ERR);
+  delete codec_filter;
+
+  codec_filter = new CodecDeltaEncode(TILEDB_INT32, 2);
+  CHECK(codec_filter->stride() == 2);
+
+  std::vector<int32_t> vector1(10);
+  // Fill vector with 1,2,3,4...
+  for (auto i=0u; i<10; i++) {
+    vector1[i] = i+1;
+  }
+  CHECK(codec_filter->code(reinterpret_cast<unsigned char*>(vector1.data()), 10*sizeof(int64_t)) == TILEDB_CDF_OK);
+  CHECK(vector1[0] == 1);
+  for (auto i=1u; i<10; i++) {
+    CHECK(vector1[i] == 2);
+  }
+  CHECK(codec_filter->decode(reinterpret_cast<unsigned char*>(vector1.data()), 10*sizeof(int64_t)) == TILEDB_CDF_OK);
+  for (auto i=0u; i<10; i++) {
+    CHECK(vector1[i] == i+1);
+  }
+  delete codec_filter;
+
+  codec_filter = new CodecDeltaEncode(TILEDB_INT64);
+  CHECK(codec_filter->type() == TILEDB_INT64);
+  delete codec_filter;
+
+  codec_filter = new CodecDeltaEncode(TILEDB_UINT32);
+  CHECK(codec_filter->type() == TILEDB_UINT32);
+  delete codec_filter;
+  
+}


### PR DESCRIPTION
To keep things forward and backward compatible, I am trying to fit the filter into the compression field which is only a `char` in the serialized binary schema. Basically, the leading two bits specify the post compression filter, the next two bits the pre compression filter and the last 4 bits the compression algorithm. Also, dropped the normalizing of compression levels because the intel Zlib has levels outside the official range if we ever want to use those.