### PR TITLE
Minor cleanup

### DIFF
--- a/core/src/array/array_schema.cc
+++ b/core/src/array/array_schema.cc
@@ -1647,7 +1647,7 @@ int ArraySchema::set_offsets_compression(int* offsets_compression) {
     for(int i=0; i<attribute_num_; ++i) {
       if (cell_val_num_[i] == TILEDB_VAR_NUM) {
         if ((compression_[i] > TILEDB_NO_COMPRESSION && offsets_compression[i] == TILEDB_NO_COMPRESSION) ||
-            (compression_[i] == TILEDB_NO_COMPRESSION && offsets_compression[i] >= TILEDB_NO_COMPRESSION)) {
+            (compression_[i] == TILEDB_NO_COMPRESSION && offsets_compression[i] > TILEDB_NO_COMPRESSION)) {
           std::string errmsg = "Unsupported. For a given VAR attribute, both compression and offsets_compression have to either have compression or not\n";
           PRINT_ERROR(errmsg);
           tiledb_as_errmsg = TILEDB_AS_ERRMSG + errmsg;

--- a/test/inputs/benchmark.config
+++ b/test/inputs/benchmark.config
@@ -64,3 +64,4 @@ Cells_To_Read=10000000
 
 # Optional - Default is 1(True)
 Print_Human_Readable_Sizes=1
+Print_Array_Schema=1

--- a/test/src/benchmark/test_sparse_array_benchmark.cc
+++ b/test/src/benchmark/test_sparse_array_benchmark.cc
@@ -49,6 +49,7 @@ TEST_CASE_METHOD(BenchmarkConfig, "Benchmark sparse array", "[benchmark_sparse]"
   create_workspace(this);
 
   // Create Arrays
+  std::cout << "Number of arrays to create=" << std::to_string(array_names_.size()) << std::endl;
   Catch::Timer t;
   t.start();
   std::vector<std::thread> threads;
@@ -62,6 +63,7 @@ TEST_CASE_METHOD(BenchmarkConfig, "Benchmark sparse array", "[benchmark_sparse]"
   std::cout << "Create arrays elapsed time = " << t.getElapsedMilliseconds() << "ms" << std::endl;
 
   // Write Arrays
+  std::cout << "\nNumber of cells to write= " << std::to_string(num_cells_to_write_) << std::endl;
   auto total_elapsed_time = 0ul;
   for (auto j=0; j<fragments_per_array_; j++) {
     threads.clear();
@@ -77,7 +79,7 @@ TEST_CASE_METHOD(BenchmarkConfig, "Benchmark sparse array", "[benchmark_sparse]"
     total_elapsed_time += t.getElapsedMilliseconds();
     free_buffers();
   }
-  std::cerr << "\nWrite I/O Mode=" << get_io_write_mode(io_write_mode_) << std::endl;
+  std::cerr << "Write I/O Mode=" << get_io_write_mode(io_write_mode_) << std::endl;
   std::cerr << "Write Mode=" << get_array_mode(array_write_mode_) << std::endl;
   std::cerr << "Number of fragments per array = " << std::to_string(fragments_per_array_) << std::endl;
   std::cerr << "Write arrays elapsed time = " << total_elapsed_time << "ms" << std::endl;
@@ -86,6 +88,7 @@ TEST_CASE_METHOD(BenchmarkConfig, "Benchmark sparse array", "[benchmark_sparse]"
   }
 
   // Read Arrays
+  std::cout << "\nNumber of cells to write= " << std::to_string(num_cells_to_read_) << std::endl;
   threads.clear();
   create_buffers(false);
   for (auto i=0ul; i<array_names_.size(); i++) {


### PR DESCRIPTION
- One bug fix in array_schema
- Just improvements to benchmarking code. Here is a comparison chart (times are comparable among all the codecs) -
```
Number of cells = i     Without compression Size=78MB
Alg.for cell    ZLIB    LZ4     LZ4+BitShuffle
-----------------------------------------------
i<<2            12MB    38MB    2MB
i%2             419KB   507KB   488KB
(i%2)-1         12MB    38MB    1MB
i%3             488KB   517KB   556KB
(i%3)-1         485KB   556KB   595KB
rand()%2        3MB     15MB    1MB
(rand()%3)-1    4MB     19MB    2MB
rand()%3        4MB     19MB    2MB
```