### PR TITLE
Get Array::write() to return tiledb_errmsg for all write modes

### DIFF
--- a/core/src/array/array.cc
+++ b/core/src/array/array.cc
@@ -995,22 +995,19 @@ int Array::write(const void** buffers, const size_t* buffer_sizes) {
   }
 
   // Write based on mode
-  int rc = TILEDB_AR_OK;
-
   if(mode_ == TILEDB_ARRAY_WRITE_SORTED_COL ||
      mode_ == TILEDB_ARRAY_WRITE_SORTED_ROW) { 
-    rc = array_sorted_write_state_->write(buffers, buffer_sizes); 
+    if (array_sorted_write_state_->write(buffers, buffer_sizes) != TILEDB_ASWS_OK) {
+      tiledb_ar_errmsg = tiledb_asws_errmsg;
+      return TILEDB_AR_ERR;
+    }
   } else if(mode_ == TILEDB_ARRAY_WRITE ||
             mode_ == TILEDB_ARRAY_WRITE_UNSORTED) { 
-    rc = write_default(buffers, buffer_sizes);
+    if (write_default(buffers, buffer_sizes) != TILEDB_AR_OK) {
+      return TILEDB_AR_ERR;
+    }
   } else {
     assert(0);
-  }
-
-  // Handle error
-  if(rc != TILEDB_ASWS_OK) {
-    tiledb_ar_errmsg = tiledb_asws_errmsg;
-    return TILEDB_AR_ERR;
   }
 
   // In all modes except TILEDB_ARRAY_WRITE, the fragment must be finalized

--- a/core/src/fragment/write_state.cc
+++ b/core/src/fragment/write_state.cc
@@ -540,7 +540,7 @@ int WriteState::write_segment(int attribute_id, bool is_var, const void *segment
   if (rc != TILEDB_UT_OK) {
     std::string errmsg = "Cannot write segment to file";
     PRINT_ERROR(errmsg);
-    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg;
+    tiledb_ws_errmsg = TILEDB_WS_ERRMSG + errmsg + '\n' + tiledb_ut_errmsg;
     return TILEDB_WS_ERR;
   }
 


### PR DESCRIPTION
Array::write() was returning tiledb_errmsg only for `TILEDB_ARRAY_WRITE_SORTED_COL` and `TILEDB_ARRAY_WRITE_SORTED_ROW` modes. Get it to return the message for all modes as downstream clients like GenomicsDB rely on tiledb_errmsg for propagation in std::exception messages.