### PR TITLE
 Add support for enable_shared_posixfs_optimizations through tiledb context. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,11 +83,12 @@ find_package(libuuid REQUIRED)
 include_directories(${LIBUUID_INCLUDE_DIR})
 
 set(TILEDB_LIB_DEPENDENCIES ${ZLIB_LIBRARIES} ${LIBUUID_LIBRARY})
-find_package(LZ4)
+
+#find_package(LZ4)
 #include_directories(${LZ4_INCLUDE_DIR})
-if(LZ4_FOUND)
-  set(TILEDB_LIB_DEPENDENCIES ${TILEDB_LIB_DEPENDENCIES} ${LZ4_LIBRARIES})
-endif()
+#if(LZ4_FOUND)
+#  set(TILEDB_LIB_DEPENDENCIES ${TILEDB_LIB_DEPENDENCIES} ${LZ4_LIBRARIES})
+#endif()
 
 if(ENABLE_BLOSC)
     find_package(BLOSC REQUIRED)

--- a/core/include/c_api/tiledb.h
+++ b/core/include/c_api/tiledb.h
@@ -6,7 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -120,9 +120,11 @@ typedef struct TileDB_Config {
    */
   int write_method_;
   /*
-   * Disables file locking even if the underlying storage system supports it
+   * Allows some optimizations like disable file locking and keeping file handles open until explicitly closed
+   * to help minimize excessive writes and other unpredictable behavior on shared posix systems like NFS and Lustre.
+   * These can be overridden with env TILEDB_DISABLE_FILE_LOCKING and TILEDB_KEEP_FILE_HANDLES_OPEN.
    */
-  bool disable_file_locking_;
+  bool enable_shared_posixfs_optimizations_;
 } TileDB_Config; 
 
 

--- a/core/include/c_api/tiledb_utils.h
+++ b/core/include/c_api/tiledb_utils.h
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2018 Omics Data Automation Inc. and Intel Corporation
+ * @copyright Copyright (c) 2020 Omics Data Automation Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,7 +43,7 @@ namespace TileDBUtils {
 
 bool is_cloud_path(const std::string& path);
 
-int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool overwrite=false, const bool disable_file_locking=false);
+int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool overwrite=false);
 
 int create_workspace(const std::string &workspace, bool replace=false);
 

--- a/core/include/c_api/tiledb_utils.h
+++ b/core/include/c_api/tiledb_utils.h
@@ -43,7 +43,8 @@ namespace TileDBUtils {
 
 bool is_cloud_path(const std::string& path);
 
-int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool overwrite=false);
+int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool overwrite=false,
+                         const bool enable_shared_posixfs_optimizations=false);
 
 int create_workspace(const std::string &workspace, bool replace=false);
 

--- a/core/include/storage_manager/storage_fs.h
+++ b/core/include/storage_manager/storage_fs.h
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2018-2019 Omics Data Automation Inc. and Intel Corporation
+ * @copyright Copyright (c) 2020 Omics Data Automation Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -87,13 +88,6 @@ class StorageFS {
   virtual int close_file(const std::string& filename);
 
   virtual bool locking_support();
-
-  void set_disable_file_locking(const bool val);
-
-  bool disable_file_locking();
- private:
-  bool disable_file_locking_ = false;
-  bool is_disable_file_locking_set = false;
 };
 
 #endif /* __STORAGE_FS_H__ */

--- a/core/include/storage_manager/storage_manager_config.h
+++ b/core/include/storage_manager/storage_manager_config.h
@@ -6,7 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ class StorageManagerConfig {
    *          TileDB will use POSIX write.
    *        - TILEDB_IO_MPI
    *          TileDB will use MPI-IO write.
-   * @param disable_file_locking disable locks in POSIX fs if set
+   * @param enable_shared_posixfs_optimizations in POSIX fs if set
    * @return void. 
    */
   int init(
@@ -115,7 +115,7 @@ class StorageManagerConfig {
       MPI_Comm* mpi_comm,
       int read_method,
       int write_methods,
-      const bool disable_file_locking);
+      const bool enable_shared_posixfs_optimizations);
 #else
   /**
    * Initializes the configuration parameters.
@@ -135,14 +135,14 @@ class StorageManagerConfig {
    *          TileDB will use POSIX write.
    *        - TILEDB_IO_MPI
    *          TileDB will use MPI-IO write.
-   * @param disable_file_locking disable locks in POSIX fs if set
+   * @param enable_shared_posixfs_optimizations if set
    * @return void. 
    */
   int init(
       const char* home,
       int read_method,
       int write_method,
-      const bool disable_file_locking);
+      const bool enable_shared_posixfs_optimizations);
 #endif
  
   /* ********************************* */

--- a/core/include/storage_manager/storage_posixfs.h
+++ b/core/include/storage_manager/storage_posixfs.h
@@ -5,6 +5,8 @@
  *
  * The MIT License
  *
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -66,18 +68,27 @@ class PosixFS : public StorageFS {
     
   int sync_path(const std::string& path);
 
-  bool keep_write_file_handles_open();
-
   bool locking_support();
 
   int close_file(const std::string& filename);
 
-  protected:
+  void set_keep_write_file_handles_open(const bool val);
+
+  bool keep_write_file_handles_open();
+
+  void set_disable_file_locking(const bool val);
+
+  bool disable_file_locking();
+
+  private:
   std::mutex write_map_mtx_;
   std::unordered_map<std::string, int> write_map_;
 
   bool keep_write_file_handles_open_set_ = false;
   bool keep_write_file_handles_open_ = false;
+
+  bool is_disable_file_locking_set = false;
+  bool disable_file_locking_ = false;
 
   int write_to_file_keep_file_handles_open(const std::string& filename, const void *buffer, size_t buffer_size);
 };

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -6,7 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corp.
- * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -116,7 +116,7 @@ int tiledb_ctx_init(
 #endif
         tiledb_config->read_method_, 
         tiledb_config->write_method_,
-        tiledb_config->disable_file_locking_) == TILEDB_SMC_ERR) {
+        tiledb_config->enable_shared_posixfs_optimizations_) == TILEDB_SMC_ERR) {
       strcpy(tiledb_errmsg, tiledb_smc_errmsg.c_str());
       return TILEDB_ERR;
     }

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -1860,15 +1860,15 @@ size_t file_size(const TileDB_CTX* tiledb_ctx, const std::string& file) {
   return 0;
 }
 
-inline bool invoke_int_fs_fn(const TileDB_CTX* tiledb_ctx, const std::string& dir, int (*fn)(StorageFS*, const std::string&)) {
+inline int invoke_int_fs_fn(const TileDB_CTX* tiledb_ctx, const std::string& dir, int (*fn)(StorageFS*, const std::string&)) {
   if (sanity_check_fs(tiledb_ctx)) {
     tiledb_fs_errmsg.clear(); 
-    bool rc = fn(tiledb_ctx->storage_manager_->get_config()->get_filesystem(), dir);
+    int rc = fn(tiledb_ctx->storage_manager_->get_config()->get_filesystem(), dir);
     if (!tiledb_fs_errmsg.empty())
       strcpy(tiledb_errmsg, tiledb_fs_errmsg.c_str()); 
     return rc;
   }
-  return false;
+  return TILEDB_ERR;
 }
 
 int set_working_dir(const TileDB_CTX* tiledb_ctx, const std::string& dir) {

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -92,15 +92,8 @@ int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace,
 
   if (is_workspace(*ptiledb_ctx, workspace)) {
     if (replace) {
-      rc = tiledb_delete(*ptiledb_ctx, workspace.c_str());
-      if (rc != TILEDB_OK) {
-        snprintf(tiledb_errmsg, TILEDB_ERRMSG_MAX_LEN, "Workspace=%s may have non-tiledb artifacts. Deleting them all!!", workspace.c_str());
-#ifdef TILEDB_VERBOSE
-        std::cerr << "[TileDB::Utils] Warning:" << tiledb_errmsg << std::endl;
-#endif
-        if (!delete_dir(*ptiledb_ctx, workspace.c_str())) {
-          return NOT_CREATED;
-        }
+      if (is_dir(*ptiledb_ctx, workspace) && delete_dir(*ptiledb_ctx, workspace) ) {
+        return NOT_CREATED;
       }
     } else {
       return UNCHANGED;

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -45,13 +45,12 @@
 
 namespace TileDBUtils {
 
-static int setup(TileDB_CTX **ptiledb_ctx, const std::string& home, const bool disable_file_locking=false)
+static int setup(TileDB_CTX **ptiledb_ctx, const std::string& home)
 {
   int rc;
   TileDB_Config tiledb_config;
   memset(&tiledb_config, 0, sizeof(TileDB_Config));
   tiledb_config.home_ = strdup(home.c_str());
-  tiledb_config.disable_file_locking_ = disable_file_locking;
   rc = tiledb_ctx_init(ptiledb_ctx, &tiledb_config);
   return rc;
 }
@@ -75,11 +74,11 @@ bool is_cloud_path(const std::string& path) {
 #define NOT_DIR -1
 #define NOT_CREATED -2
 #define UNCHANGED 1
-int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool replace, const bool disable_file_locking)
+int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool replace)
 {
   *ptiledb_ctx = NULL;
   int rc;
-  rc = setup(ptiledb_ctx, workspace, disable_file_locking);
+  rc = setup(ptiledb_ctx, workspace);
   if (rc) {
     return NOT_CREATED;
   }

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -45,12 +45,14 @@
 
 namespace TileDBUtils {
 
-static int setup(TileDB_CTX **ptiledb_ctx, const std::string& home)
+static int setup(TileDB_CTX **ptiledb_ctx, const std::string& home,
+                 const bool enable_shared_posixfs_optimizations=false)
 {
   int rc;
   TileDB_Config tiledb_config;
   memset(&tiledb_config, 0, sizeof(TileDB_Config));
   tiledb_config.home_ = strdup(home.c_str());
+  tiledb_config.enable_shared_posixfs_optimizations_ = enable_shared_posixfs_optimizations;
   rc = tiledb_ctx_init(ptiledb_ctx, &tiledb_config);
   return rc;
 }
@@ -74,11 +76,12 @@ bool is_cloud_path(const std::string& path) {
 #define NOT_DIR -1
 #define NOT_CREATED -2
 #define UNCHANGED 1
-int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool replace)
+int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool replace,
+                         const bool enable_shared_posixfs_optimizations)
 {
   *ptiledb_ctx = NULL;
   int rc;
-  rc = setup(ptiledb_ctx, workspace);
+  rc = setup(ptiledb_ctx, workspace, enable_shared_posixfs_optimizations);
   if (rc) {
     return NOT_CREATED;
   }

--- a/core/src/storage_manager/storage_fs.cc
+++ b/core/src/storage_manager/storage_fs.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -54,25 +54,3 @@ bool StorageFS::locking_support() {
   return false;
 }
 
-void StorageFS::set_disable_file_locking(const bool val) {
-  disable_file_locking_ = val;
-}
-
-bool StorageFS::disable_file_locking() {
-  if (is_disable_file_locking_set) {
-    return disable_file_locking_;
-  }
-
-  is_disable_file_locking_set = true;
-
-  if(disable_file_locking_)
-    return true;
-
-  auto env_var = getenv("TILEDB_DISABLE_FILE_LOCKING");
-  if(env_var && (strcasecmp(env_var, "true") == 0 || strcmp(env_var, "1") == 0)) {
-    disable_file_locking_ = true;
-    return true;
-  }
-  disable_file_locking_ = false;
-  return false;
-}

--- a/core/src/storage_manager/storage_manager_config.cc
+++ b/core/src/storage_manager/storage_manager_config.cc
@@ -6,7 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -86,7 +86,7 @@ int StorageManagerConfig::init(
 #endif
     int read_method,
     int write_method,
-    const bool disable_file_locking) {
+    const bool enable_shared_posixfs_optimizations) {
   // Initialize home
   if (strstr(home, "://")) {
      if (fs_ != NULL)
@@ -115,8 +115,11 @@ int StorageManagerConfig::init(
      return TILEDB_SMC_OK;
    }
 
-   if (fs_ == NULL)
+  if (fs_ == NULL) {
      fs_ = new PosixFS();
+     dynamic_cast<PosixFS *>(fs_)->set_disable_file_locking(enable_shared_posixfs_optimizations);
+     dynamic_cast<PosixFS *>(fs_)->set_keep_write_file_handles_open(enable_shared_posixfs_optimizations);
+  }
 
    if(home == NULL) {
      home_ = "";
@@ -142,11 +145,8 @@ int StorageManagerConfig::init(
      write_method_ != TILEDB_IO_MPI)
     write_method_ = TILEDB_IO_WRITE;  // Use default 
 
-  fs_->set_disable_file_locking(disable_file_locking);
-
   return TILEDB_SMC_OK;
 }
-
 
 /* ****************************** */
 /*            ACCESSORS           */

--- a/core/src/storage_manager/storage_posixfs.cc
+++ b/core/src/storage_manager/storage_posixfs.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -554,17 +554,36 @@ int PosixFS::close_file(const std::string& filename) {
   return TILEDB_FS_OK;
 }
 
+bool PosixFS::locking_support() {
+  return !disable_file_locking();
+}
+
+void PosixFS::set_keep_write_file_handles_open(const bool val) {
+  keep_write_file_handles_open_ = val;
+}
+
 bool PosixFS::keep_write_file_handles_open() {
   if (keep_write_file_handles_open_set_) {
     return keep_write_file_handles_open_;
   }
-
-  keep_write_file_handles_open_ = is_env_set("TILEDB_KEEP_FILE_HANDLES_OPEN");
+  if (getenv("TILEDB_KEEP_FILE_HANDLES_OPEN")) {
+    keep_write_file_handles_open_ = is_env_set("TILEDB_KEEP_FILE_HANDLES_OPEN");
+  }
   keep_write_file_handles_open_set_ = true;
-
   return keep_write_file_handles_open_;
 }
 
-bool PosixFS::locking_support() {
-  return !disable_file_locking();
+void PosixFS::set_disable_file_locking(const bool val) {
+  disable_file_locking_ = val;
+}
+
+bool PosixFS::disable_file_locking() {
+  if (is_disable_file_locking_set) {
+    return disable_file_locking_;
+  }
+  if (getenv("TILEDB_DISABLE_FILE_LOCKING")) {
+    disable_file_locking_ = is_env_set("TILEDB_DISABLE_FILE_LOCKING");
+  }
+  is_disable_file_locking_set = true;
+  return disable_file_locking_;
 }

--- a/test/src/storage_manager/test_posixfs.cc
+++ b/test/src/storage_manager/test_posixfs.cc
@@ -267,6 +267,16 @@ void test_locking_support(const std::string& disable_file_locking_value) {
 }
 
 TEST_CASE("Test locking support", "[locking_support]") {
+  PosixFS fs;
+  CHECK(!fs.disable_file_locking()); // default
+  CHECK(fs.locking_support());
+  fs.set_disable_file_locking(true);
+  CHECK(fs.disable_file_locking());
+  CHECK(!fs.locking_support());
+  fs.set_disable_file_locking(false);
+  CHECK(!fs.disable_file_locking());
+  CHECK(fs.locking_support());
+
   test_locking_support("True");
   test_locking_support("true");
   test_locking_support("TRUE");
@@ -294,6 +304,13 @@ void test_keep_file_handles_open_support(const std::string& keep_file_handles_op
 }
 
 TEST_CASE("Test keep file handles open", "[keep_file_handles_open_support]") {
+  PosixFS fs;
+  CHECK(!fs.keep_write_file_handles_open()); // default
+  fs.set_keep_write_file_handles_open(true);
+  CHECK(fs.keep_write_file_handles_open());
+  fs.set_keep_write_file_handles_open(false);
+  CHECK(!fs.keep_write_file_handles_open());
+
   test_keep_file_handles_open_support("True");
   test_keep_file_handles_open_support("true");
   test_keep_file_handles_open_support("TRUE");
@@ -356,6 +373,7 @@ TEST_CASE("Test writing with keeps file descriptors open until explicitly closed
 
   free(buffer);
 }
+
 
 
 TEST_CASE("Test reading/writing with keep file handles open set for write and unset for read", "[write_keep_file_handles_set_write_unset_read]") {


### PR DESCRIPTION
Add support for `enable_shared_posixfs_optimizations` instead of `disable_file_locking` through tiledb context. This sets disable_file_locking and keep_file_handles_open for posix filesystems.
In addition -

- In TileDBUtils::initialize workspace, just delete the workspace dir when replace is set to true. This handles cases like GenomicsDB workspace that have non-TileDB artifacts.
- Removed support for linking with external lz4 libraries TileDB will only be linked with lz4 objects compiled from source for now.