### PR TITLE
uint8_t support for JPEG2K compressions

### DIFF
--- a/core/include/codec/codec_jpeg2K.h
+++ b/core/include/codec/codec_jpeg2K.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -63,6 +63,8 @@ JPEG2K_EXTERN_DECL opj_stream_t* (*opj_stream_create_memory_stream)(void *, OPJ_
 JPEG2K_EXTERN_DECL OPJ_BOOL (*opj_setup_decoder)(opj_codec_t *, opj_dparameters_t *);
 JPEG2K_EXTERN_DECL OPJ_BOOL (*opj_read_header)(opj_stream_t *, opj_codec_t *, opj_image_t **);
 JPEG2K_EXTERN_DECL OPJ_BOOL (*opj_set_decode_area)(opj_codec_t *, opj_image_t *, int, int, int, int);
+JPEG2K_EXTERN_DECL opj_image_t* (*opj_image_tile_create)(OPJ_UINT32, opj_image_cmptparm_t *, OPJ_COLOR_SPACE);
+JPEG2K_EXTERN_DECL OPJ_BOOL (*opj_write_tile)(opj_codec_t *, OPJ_UINT32, OPJ_BYTE *, OPJ_UINT32 , opj_stream_t *);
 JPEG2K_EXTERN_DECL OPJ_BOOL (*opj_read_tile_header)(opj_codec_t *, opj_stream_t *, OPJ_UINT32 *, OPJ_UINT32 *, OPJ_INT32 *, OPJ_INT32 *, OPJ_INT32 *, OPJ_INT32 *, OPJ_UINT32 *, OPJ_BOOL *);
 JPEG2K_EXTERN_DECL OPJ_BOOL (*opj_decode_tile_data)(opj_codec_t *, OPJ_UINT32, OPJ_BYTE *, OPJ_UINT32, opj_stream_t *);
 JPEG2K_EXTERN_DECL OPJ_BOOL (*opj_end_decompress)(opj_codec_t *, opj_stream_t *);
@@ -106,6 +108,8 @@ class CodecJPEG2K_base : public Codec {
 	  BIND_SYMBOL(dl_handle_, opj_setup_decoder, "opj_setup_decoder", (OPJ_BOOL(*)(opj_codec_t *, opj_dparameters_t *)));
 	  BIND_SYMBOL(dl_handle_, opj_read_header, "opj_read_header", (OPJ_BOOL(*)(opj_stream_t *, opj_codec_t *, opj_image_t **)));
 	  BIND_SYMBOL(dl_handle_, opj_set_decode_area, "opj_set_decode_area", (OPJ_BOOL(*)(opj_codec_t *, opj_image_t *, int, int, int, int)));
+	  BIND_SYMBOL(dl_handle_, opj_image_tile_create, "opj_image_tile_create", (opj_image_t*(*)(OPJ_UINT32, opj_image_cmptparm_t *, OPJ_COLOR_SPACE)));
+	  BIND_SYMBOL(dl_handle_, opj_write_tile, "opj_write_tile", (OPJ_BOOL(*)(opj_codec_t *, OPJ_UINT32, OPJ_BYTE *, OPJ_UINT32, opj_stream_t *)));
 	  BIND_SYMBOL(dl_handle_, opj_read_tile_header, "opj_read_tile_header", (OPJ_BOOL(*)(opj_codec_t *, opj_stream_t *, OPJ_UINT32 *, OPJ_UINT32 *, OPJ_INT32 *, OPJ_INT32 *, OPJ_INT32 *, OPJ_INT32 *, OPJ_UINT32 *, OPJ_BOOL *)));
 	  BIND_SYMBOL(dl_handle_, opj_decode_tile_data, "opj_decode_tile_data", (OPJ_BOOL(*)(opj_codec_t *, OPJ_UINT32, OPJ_BYTE *, OPJ_UINT32, opj_stream_t *)));
 	  BIND_SYMBOL(dl_handle_, opj_end_decompress, "opj_end_decompress", (OPJ_BOOL(*)(opj_codec_t *, opj_stream_t *)));

--- a/core/src/codec/codec_jpeg2K.cc
+++ b/core/src/codec/codec_jpeg2K.cc
@@ -256,6 +256,7 @@ int CodecJPEG2K::compress_tile(unsigned char* tile_in, size_t tile_size_in, void
    opj_image_t * l_image;
    opj_image_cmptparm_t l_image_params;   // only need one component
    opj_stream_t * l_stream;
+   size_t opj_compress_size;
 
    OPJ_UINT32 i;
    OPJ_BYTE *l_data;
@@ -393,9 +394,13 @@ int CodecJPEG2K::compress_tile(unsigned char* tile_in, size_t tile_size_in, void
       return print_errmsg("jpeg2k_compress: failed to end compress");
    }
 
-   *tile_compressed = opj_mem_stream_copy(l_stream, &tile_compressed_size);
+   tile_compressed_ = opj_mem_stream_copy(l_stream, &opj_compress_size);
 
    cleanup(NULL, l_stream, l_codec, l_image);
+
+   // Set output
+   *tile_compressed = tile_compressed_;
+   tile_compressed_size = opj_compress_size;
 
    // Success
    return TILEDB_CD_OK;
@@ -559,6 +564,7 @@ int CodecJPEG2K_RGB::compress_tile(unsigned char* tile_in, size_t tile_size_in, 
    opj_image_t * l_image;
    opj_image_cmptparm_t l_image_params[NUM_COMPS_MAX];
    opj_stream_t * l_stream;
+   size_t opj_compress_size;
 
    opj_image_cmptparm_t * l_current_param_ptr;
    OPJ_UINT32 i;
@@ -680,13 +686,6 @@ int CodecJPEG2K_RGB::compress_tile(unsigned char* tile_in, size_t tile_size_in, 
 // Copy pixels to l_image component data from l_data (tile_in)
 
    OPJ_UINT32 num_pixels = num_comps * image_width * image_height;
-/*
-   size_t num_bytes = num_pixels * sizeof(OPJ_INT32);
-   for (compno = 0; compno < num_comps; ++compno) {
-      memcpy(l_image->comps[compno].data, l_data, num_bytes);
-      l_data += num_pixels;
-   }
-*/
 
 /**
  * to debug by comparing image information and parameters from external run
@@ -710,7 +709,6 @@ int CodecJPEG2K_RGB::compress_tile(unsigned char* tile_in, size_t tile_size_in, 
       return print_errmsg("jpeg2k_compress: failed to start compress");
    }
 
-//CPB if (! opj_encode(l_codec, l_stream)) {
    if (! opj_write_tile(l_codec, 0, l_data, num_pixels, l_stream)) {
       cleanup(NULL, l_stream, l_codec, l_image);
       return print_errmsg("jpeg2k_compress: failed to encode the tile");
@@ -721,9 +719,13 @@ int CodecJPEG2K_RGB::compress_tile(unsigned char* tile_in, size_t tile_size_in, 
       return print_errmsg("jpeg2k_compress: failed to end compress");
    }
 
-   *tile_compressed = opj_mem_stream_copy(l_stream, &tile_compressed_size);
+   tile_compressed_ = opj_mem_stream_copy(l_stream, &opj_compress_size);
 
    cleanup(NULL, l_stream, l_codec, l_image);
+
+   // Set output
+   *tile_compressed = tile_compressed_;
+   tile_compressed_size = opj_compress_size;
 
    // Success
    return TILEDB_CD_OK;

--- a/examples/src/tiledb_image_create_binary_1.cc
+++ b/examples/src/tiledb_image_create_binary_1.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  * 
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,11 +48,11 @@ int main(int argc, char *argv[]) {
   // Prepare parameters for array schema
   const char* array_name = "my_workspace/image_arrays/tissue150165";
   const char* attributes[] = { "R", "G", "B" };      // Three channels
-  const char* dimensions[] = { "width", "height" };  // 2-D image dimensions
+  const char* dimensions[] = { "height", "width" };  // 2-D image dimensions
   int64_t domain[] = 
   { 
-      0, 149,                        // width
-      0, 164                         // height
+      0, 164,                         // height
+      0, 149                          // width
   };                
   const int cell_val_num[] = 
   { 
@@ -74,15 +74,15 @@ int main(int argc, char *argv[]) {
   };
   int64_t tile_extents[] = 
   { 
-      150,                        // width
-      165                         // height
+      165,                        // height
+      150                         // width
   };               
   const int types[] = 
   { 
-      TILEDB_INT32,                // R channel
-      TILEDB_INT32,                // G channel
-      TILEDB_INT32,                // B channel
-      TILEDB_INT64                 // coordinates
+      TILEDB_UINT8,               // R channel
+      TILEDB_UINT8,               // G channel
+      TILEDB_UINT8,               // B channel
+      TILEDB_INT64                // coordinates
   };
   
   // Set array schema

--- a/examples/src/tiledb_image_create_binary_2.cc
+++ b/examples/src/tiledb_image_create_binary_2.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  * 
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/examples/src/tiledb_image_create_binary_2.cc
+++ b/examples/src/tiledb_image_create_binary_2.cc
@@ -28,7 +28,7 @@
  * @section DESCRIPTION
  *
  * Example to create dense array to hold whole 165x150 binary image using 
- *   TILEDB_JPEG2K_RGB compression
+ *   TILEDB JPEG2K_RGB compression
  *
  */
 
@@ -48,6 +48,7 @@ int main(int argc, char *argv[]) {
 
   // Prepare parameters for array schema
   const char* array_name = "my_workspace/image_arrays/tissue165150";
+  int cell_V_Num = 3*165*150*sizeof(uint8_t) + 3*sizeof(int);
   const char* attributes[] = { "imageRGB" };      // one whole image
   const char* dimensions[] = { "one" };  // one whole image
   int64_t domain[] = 
@@ -57,7 +58,8 @@ int main(int argc, char *argv[]) {
 
   const int cell_val_num[] = 
   { 
-      74253                        // integer pixels in 3 components + header
+      cell_V_Num                        // uint8_t pixels in 3 components 
+                                        //                   + header (3*int)
   };
   const int compression[] = 
   { 
@@ -75,7 +77,7 @@ int main(int argc, char *argv[]) {
   };               
   const int types[] = 
   { 
-      TILEDB_INT32,                // imageRGB
+      TILEDB_UINT8,                // imageRGB
       TILEDB_INT64                 // coordinates
   };
   

--- a/examples/src/tiledb_image_create_panels.cc
+++ b/examples/src/tiledb_image_create_panels.cc
@@ -6,7 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,11 +49,11 @@ int main(int argc, char *argv[]) {
   // Prepare parameters for array schema
   const char* array_name = "my_workspace/image_arrays/panelimage";
   const char* attributes[] = { "R", "G", "B" };  // Three attributes
-  const char* dimensions[] = { "width", "height" };        // 2-D image dimensions
+  const char* dimensions[] = { "height", "width" };        // 2-D image dimensions
   int64_t domain[] = 
   { 
-      0, 299,                       // width
-      0, 299                        // height
+      0, 299,                       // height
+      0, 299                        // width
   };                
   const int cell_val_num[] = 
   { 
@@ -75,14 +75,14 @@ int main(int argc, char *argv[]) {
   };
   int64_t tile_extents[] = 
   { 
-      100,                          // width
-      100                           // height
+      100,                          // height
+      100                           // width
   };               
   const int types[] = 
   { 
-      TILEDB_INT32,               // R channel
-      TILEDB_INT32,               // G channel
-      TILEDB_INT32,               // B channel
+      TILEDB_UINT8,               // R channel
+      TILEDB_UINT8,               // G channel
+      TILEDB_UINT8,               // B channel
       TILEDB_INT64                // coordinates
   };
   

--- a/examples/src/tiledb_image_create_panels_RGB.cc
+++ b/examples/src/tiledb_image_create_panels_RGB.cc
@@ -6,7 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,15 +50,16 @@ int main(int argc, char *argv[]) {
   // Prepare parameters for array schema
   const char* array_name = "my_workspace/image_arrays/panelimage_RGB";
   const char* attributes[] = { "imageRGB" };          // one image
-  const char* dimensions[] = { "width", "height" };   // 2-D image dimensions
+  const char* dimensions[] = { "height", "width" };   // 2-D image dimensions
+  int cell_V_num = 3*100*100*sizeof(uint8_t) + 3*sizeof(int);
   int64_t domain[] = 
   { 
-      0, 2,                       // width
-      0, 2                        // height
+      0, 2,                       // height
+      0, 2                        // width
   };                
   const int cell_val_num[] = 
   { 
-     30003                       // integer pixels in panel plus header
+     cell_V_num                  // uint8_t pixels in panel plus header (3*int)
                                  // 3 x (100 x 100) + 3
   };
   const int compression[] = 
@@ -73,12 +74,12 @@ int main(int argc, char *argv[]) {
   };
   int64_t tile_extents[] = 
   { 
-      1,                          // width
-      1                           // height
+      1,                          // height
+      1                           // width
   };               
   const int types[] = 
   { 
-      TILEDB_INT32,               // image
+      TILEDB_UINT8,               // image
       TILEDB_INT64                // coordinates
   };
   

--- a/examples/src/tiledb_image_create_whole.cc
+++ b/examples/src/tiledb_image_create_whole.cc
@@ -6,7 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,11 +49,11 @@ int main(int argc, char *argv[]) {
   // Prepare parameters for array schema
   const char* array_name = "my_workspace/image_arrays/wholeimage";
   const char* attributes[] = { "R", "G", "B" };  // One attributes
-  const char* dimensions[] = { "width" , "height"};   // 2-D image dimensions
+  const char* dimensions[] = { "height" , "width"};   // 2-D image dimensions
   int64_t domain[] = 
   { 
-      0, 299,                        // width
-      0, 299                         // height
+      0, 299,                        // height
+      0, 299                         // width
   };                
   const int cell_val_num[] = 
   { 
@@ -77,14 +77,14 @@ int main(int argc, char *argv[]) {
   };
   int64_t tile_extents[] = 
   { 
-      300,                           // width
-      300                            // height
+      300,                           // height
+      300                            // width
   };               
   const int types[] = 
   { 
-      TILEDB_INT32,               // image
-      TILEDB_INT32,               // image
-      TILEDB_INT32,               // image
+      TILEDB_UINT8,               // image
+      TILEDB_UINT8,               // image
+      TILEDB_UINT8,               // image
       TILEDB_INT64                // coordinates
   };
   

--- a/examples/src/tiledb_image_read_panels.cc
+++ b/examples/src/tiledb_image_read_panels.cc
@@ -6,7 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,10 +35,10 @@
 #include "examples.h"
 #include <stdlib.h>
 
-void check_results(int *buffer_image)
+void check_results(uint8_t* buffer_image)
 {
 
-   int R[10], G[10], B[10];
+   uint8_t R[10], G[10], B[10];
 //       Black,        Red,          Orange
    R[0] =   0;   R[1] = 201;   R[2] = 234;
    G[0] =   0;   G[1] =  23;   G[2] =  85;
@@ -59,7 +59,7 @@ void check_results(int *buffer_image)
    G[9] = 130;
    B[9] = 130;
 
-   int *l_data = buffer_image;
+   uint8_t* l_data = buffer_image;
    int num_comps = 3, width = 300, height = 300;
 
    size_t c, i, j, k;
@@ -141,10 +141,10 @@ int main(int argc, char *argv[]) {
    size_t panel_height = 100;  // per panel
    size_t num_panels = 9;
    size_t num_panel_pixels = panel_width * panel_height;
-   size_t buffer_bytes = num_panels * (num_panel_pixels * sizeof(int));
-   size_t full_image_bytes  = num_comps *img_width * img_height * sizeof(int);
+   size_t buffer_bytes = num_panels * (num_panel_pixels * sizeof(uint8_t));
+   size_t full_image_bytes  = num_comps *img_width * img_height * sizeof(uint8_t);
  
-   int* buffer_image = (int*)malloc(full_image_bytes);
+   uint8_t* buffer_image = (uint8_t*)malloc(full_image_bytes);
  
    void* buffers[] = 
    { 

--- a/examples/src/tiledb_image_read_panels_RGB.cc
+++ b/examples/src/tiledb_image_read_panels_RGB.cc
@@ -6,7 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,10 +36,10 @@
 #include <stdlib.h>
 #define HEADER_SIZE 3
 
-void check_results(int *buffer_image)
+void check_results(uint8_t *buffer_image)
 {
 
-   int R[10], G[10], B[10];
+   uint8_t R[10], G[10], B[10];
 //       Black,        Red,          Orange
    R[0] =   0;   R[1] = 201;   R[2] = 234;
    G[0] =   0;   G[1] =  23;   G[2] =  85;
@@ -60,11 +60,12 @@ void check_results(int *buffer_image)
    G[9] = 130;
    B[9] = 130;
 
-   int *l_data = buffer_image;
-   int num_comps = l_data[0];
-   int width = l_data[1];
-   int height = l_data[2];
+   int *header_data = (int*)buffer_image;
+   int num_comps = header_data[0];
+   int width = header_data[1];
+   int height = header_data[2];
    int num_panels = 9;
+   uint8_t* l_data = buffer_image;
 
    size_t i, j;
    int Rerrs[9] = {0,0,0,0,0,0,0,0,0};
@@ -86,7 +87,7 @@ void check_results(int *buffer_image)
 
    int errors = 0;
    for (i = 0; i < num_panels; ++i) {
-      l_data += 3;   // skip over panel header
+      l_data += HEADER_SIZE*sizeof(int);   // skip over panel header
       for (j = 0; j < width*height; ++j) {
          if (*l_data != R[i]) { ++Rerrs[i]; ++errors; }
          ++l_data;
@@ -146,9 +147,9 @@ int main(int argc, char *argv[]) {
    size_t panel_height = 100;  // per panel
    size_t num_panels = 9;
    size_t num_panel_pixels = num_comps * panel_width * panel_height;
-   size_t buffer_bytes = num_panels * ((num_panel_pixels + HEADER_SIZE) * sizeof(int));
+   size_t buffer_bytes = num_panels * ((num_panel_pixels * sizeof(uint8_t) + HEADER_SIZE * sizeof(int)));
  
-   int* buffer_image = (int*)malloc(buffer_bytes);
+   uint8_t* buffer_image = (uint8_t*)malloc(buffer_bytes);
  
    void* buffers[] = 
    { 

--- a/examples/src/tiledb_image_read_whole.cc
+++ b/examples/src/tiledb_image_read_whole.cc
@@ -6,7 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,10 +35,10 @@
 #include "examples.h"
 #include <stdlib.h>
 
-void check_results(int *buffer_image)
+void check_results(uint8_t* buffer_image)
 {
 
-   int R[10], G[10], B[10];
+   uint8_t R[10], G[10], B[10];
 //       Black,        Red,          Orange
    R[0] =   0;   R[1] = 201;   R[2] = 234;
    G[0] =   0;   G[1] =  23;   G[2] =  85;
@@ -60,7 +60,7 @@ void check_results(int *buffer_image)
    B[9] = 130;
 
    // Print midpoint RGB value of each palette block and check
-   int *l_data = buffer_image;
+   uint8_t* l_data = buffer_image;
    int num_comps = 3, width = 300, height = 300;
 
    size_t c, i, j, k;
@@ -137,14 +137,17 @@ int main(int argc, char *argv[]) {
    size_t num_comps = 3;
    size_t width  = 300;
    size_t height = 300;
-   size_t full_image_bytes = (num_comps * width * height) * sizeof(int);
-   size_t buffer_image_bytes = (width * height) * sizeof(int);
+   size_t full_image_pixels = num_comps * width * height;
+   size_t buffer_image_bytes = width * height * sizeof(uint8_t);
  
-   int *buffer_image = (int*)malloc(full_image_bytes);
-   void* buffers[] = { &buffer_image[0*width*height],  // R buffer
-                       &buffer_image[1*width*height],  // G buffer
-                       &buffer_image[2*width*height]   // B buffer
-                     };
+   uint8_t* buffer_image = (uint8_t*)malloc(full_image_pixels);
+   void* buffers[] = 
+   { 
+     &buffer_image[0*width*height],  // R buffer
+     &buffer_image[1*width*height],  // G buffer
+     &buffer_image[2*width*height]   // B buffer
+   };
+
    size_t buffer_sizes[] = 
    { 
        buffer_image_bytes,            // sizeof(R buffer_image)  

--- a/examples/src/tiledb_image_write_binary_1.cc
+++ b/examples/src/tiledb_image_write_binary_1.cc
@@ -6,7 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,14 +39,21 @@
 
 using namespace std;
 
-int *read_image(const char* filename, size_t num_bytes)
+uint8_t* read_image(const char* filename, size_t image_pixels)
 {
-   int *image_buffer = (int *)malloc(num_bytes);
+   size_t file_image_bytes = image_pixels * sizeof(int);
+   size_t image_bytes = image_pixels * sizeof(uint8_t);
+   int *read_image_buffer = (int *)malloc(file_image_bytes); // number of file bytes
+   uint8_t *image_buffer = (uint8_t *)malloc(image_bytes);   // number of pixel bytes
    FILE *infile;
    infile = fopen(filename, "rb"); // r for read, b for binary
-   fread(image_buffer, num_bytes, 1, infile);
+   fread(read_image_buffer, file_image_bytes, 1, infile);
    fclose(infile);
 
+   for (size_t i = 0; i < image_pixels; ++i)
+       image_buffer[i] = read_image_buffer[i];
+      
+   free(read_image_buffer);
    return image_buffer;
 }
 
@@ -77,12 +84,12 @@ int main(int argc, char *argv[]) {
   size_t num_comps = 3;
   size_t width  = 150;
   size_t height = 165;
-  size_t full_image_bytes = (num_comps * width * height) * sizeof(int);
-  size_t buffer_image_bytes = (width * height) * sizeof(int);
+  size_t full_image_pixels = num_comps * width * height;
+  size_t buffer_image_bytes = (width * height) * sizeof(uint8_t);
 
   std::string filename = std::string(TILEDB_EXAMPLE_DIR)+"/data/tissue150x165.bin";
 
-  int * buffer_image = read_image(filename.c_str(), full_image_bytes);
+  uint8_t* buffer_image = read_image(filename.c_str(), full_image_pixels);
 
   const void* buffers[] = 
   { 

--- a/examples/src/tiledb_image_write_panels.cc
+++ b/examples/src/tiledb_image_write_panels.cc
@@ -6,7 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,13 +35,13 @@
 #include "examples.h"
 #include <stdlib.h>
 
-int *build_image(size_t num_comps, size_t width, size_t height)
+uint8_t* build_image(size_t num_comps, size_t width, size_t height)
 {
-   size_t buffer_size = (num_comps * width * height) * sizeof(int);
-   int *image_buffer = (int *)malloc(buffer_size);
-   int *l_data = image_buffer;
+   size_t buffer_size = (num_comps * width * height) * sizeof(uint8_t);
+   uint8_t* image_buffer = (uint8_t*)malloc(buffer_size);
+   uint8_t* l_data = image_buffer;
 
-   int R[10], G[10], B[10];
+   uint8_t R[10], G[10], B[10];
 //       Black,        Red,          Orange
    R[0] =   0;   R[1] = 201;   R[2] = 234;
    G[0] =   0;   G[1] =  23;   G[2] =  85;
@@ -109,10 +109,9 @@ int main(int argc, char *argv[]) {
   size_t panel_height = 100;  // per panel
   size_t num_panels = 9;
   size_t num_panel_pixels = panel_width * panel_height;
-  size_t buffer_bytes = num_panels * (num_panel_pixels * sizeof(int));
-  size_t image_bytes  = img_width * img_height * sizeof(int);
+  size_t buffer_bytes = num_panels * (num_panel_pixels * sizeof(uint8_t));
 
-  int* buffer_image = build_image(num_comps, img_width, img_height);
+  uint8_t* buffer_image = build_image(num_comps, img_width, img_height);
 
   const void* buffers[] = 
   { 

--- a/examples/src/tiledb_image_write_whole.cc
+++ b/examples/src/tiledb_image_write_whole.cc
@@ -6,7 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,13 +35,13 @@
 #include "examples.h"
 #include <stdlib.h>
 
-int *build_image(size_t num_comps, size_t width, size_t height)
+uint8_t* build_image(size_t num_comps, size_t width, size_t height)
 {
-   size_t buffer_size = (num_comps * width * height) * sizeof(int);
-   int *image_buffer = (int *)malloc(buffer_size);
-   int *l_data = image_buffer;
+   size_t buffer_size = (num_comps * width * height) * sizeof(uint8_t);
+   uint8_t* image_buffer = (uint8_t*)malloc(buffer_size);
+   uint8_t* l_data = image_buffer;
 
-   int R[10], G[10], B[10];
+   uint8_t R[10], G[10], B[10];
 //       Black,        Red,          Orange
    R[0] =   0;   R[1] = 201;   R[2] = 234;
    G[0] =   0;   G[1] =  23;   G[2] =  85;
@@ -105,9 +105,9 @@ int main(int argc, char *argv[]) {
   size_t num_comps = 3;
   size_t width  = 300;
   size_t height = 300;
-  size_t image_bytes = (width * height) * sizeof(int);
+  size_t image_plane_bytes = (width * height) * sizeof(uint8_t);
 
-  int * buffer_image = build_image(num_comps, width, height);
+  uint8_t* buffer_image = build_image(num_comps, width, height);
 
   const void* buffers[] = { &buffer_image[0*width*height], 
                             &buffer_image[1*width*height], 
@@ -115,9 +115,9 @@ int main(int argc, char *argv[]) {
                           };
   size_t buffer_sizes[] = 
   { 
-      image_bytes,        // sizeof( R buffer_image )  
-      image_bytes,        // sizeof( G buffer_image )  
-      image_bytes         // sizeof( B buffer_image )  
+      image_plane_bytes,        // sizeof( R buffer_image )  
+      image_plane_bytes,        // sizeof( G buffer_image )  
+      image_plane_bytes         // sizeof( B buffer_image )  
   };
 
   // Write to array


### PR DESCRIPTION
Modified both `CodecJPEG2K` and `CodecJPEG2K_RGB` `compress_tile()` methods to only accept `uint8_t` pixel values. (This assumes that the bits per pixel, `bpp`, will be 8 for images.) Any conversion of the image from/to larger pixel types (e.g., `int32`) before compression or after decompression must be done externally to TileDB write and read operations. 

Removed the conversion from `uint8_t` to `int32` in both `decompress_tile()` methods to return only `uint8_t` pixel values.

Modified all `tiledb_image_*` example tests to work with `uint8_t` pixel values.