### PR TITLE
Use the deprecated gcs property fs.gs.io.buffersize.write as gatk still uses the 1.6.3 gcs connector

### DIFF
--- a/core/src/storage_manager/storage_gcs.cc
+++ b/core/src/storage_manager/storage_gcs.cc
@@ -137,7 +137,10 @@ hdfsFS gcs_connect(struct hdfsBuilder *builder, const std::string& working_dir) 
   // Default buffer sizes are huge in the GCS connector. TileDB reads/writes in smaller chunks,
   // so the buffer size can be made a little smaller.
   hdfsBuilderConfSetStr(builder, "fs.gs.outputstream.upload.chunk.size", "262144");
-    
+
+  // This is deprecated in the newer versions. But, gatk uses a very old version of the gcs connector.
+  hdfsBuilderConfSetStr(builder, "fs.gs.io.buffersize.write", "262144");
+
   hdfsFS hdfs_handle = hdfsBuilderConnect(builder);
   free(value);
   return hdfs_handle;


### PR DESCRIPTION
gatk with the snapshot version seems to be working fine - see build https://travis-ci.com/github/broadinstitute/gatk/builds/170730609.

Wondering if I should leave the newer `fs.gs.outputstream.upload.chunk.size` in? Also, we need to make this configurable or somehow dovetail with the Java Heap Size options.