### PR TITLE
Start using Hadoop 3 for testing

### DIFF
--- a/.travis/scripts/install_hadoop.sh
+++ b/.travis/scripts/install_hadoop.sh
@@ -6,7 +6,7 @@
 INSTALL_DIR=${INSTALL_DIR:-/usr}
 USER=`whoami`
 
-HADOOP=hadoop-${HADOOP_VER:-2.9.2}
+HADOOP=hadoop-${HADOOP_VER:-3.2.1}
 HADOOP_DIR=${INSTALL_DIR}/$HADOOP
 
 install_prereqs() {
@@ -24,10 +24,10 @@ install_prereqs() {
 
 download_gcs_connector() {
   if [[ $INSTALL_TYPE == gcs ]]; then
-    wget -q https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-latest-hadoop2.jar
-	mv gcs-connector-latest-hadoop2.jar ${HADOOP_DIR}/share/hadoop/common
-	echo "Listing ${HADOOP_DIR}/share/hadoop/common"
-	ls -l ${HADOOP_DIR}/share/hadoop/common
+    wget -q https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar
+	  mv gcs-connector-hadoop3-latest.jar ${HADOOP_DIR}/share/hadoop/common
+    echo "Listing ${HADOOP_DIR}/share/hadoop/common"
+	  ls -l ${HADOOP_DIR}/share/hadoop/common
   fi
 }
 
@@ -52,7 +52,6 @@ configure_hadoop() {
   configure_passphraseless_ssh &&
   cp -fr $TRAVIS_BUILD_DIR/.travis/resources/hadoop/* $HADOOP_DIR/etc/hadoop &&
   mkdir $HADOOP_DIR/logs &&  
-  $HADOOP_DIR/bin/hadoop &&
   $HADOOP_DIR/bin/hadoop namenode -format &&
   $HADOOP_DIR/sbin/start-dfs.sh &&
   echo "configure_hadoop successful"

--- a/.travis/scripts/install_hadoop.sh
+++ b/.travis/scripts/install_hadoop.sh
@@ -51,6 +51,7 @@ configure_passphraseless_ssh() {
 configure_hadoop() {
   configure_passphraseless_ssh &&
   cp -fr $TRAVIS_BUILD_DIR/.travis/resources/hadoop/* $HADOOP_DIR/etc/hadoop &&
+  rm -f $HADOOP_DIR/etc/hadoop/hadoop-metrics2.properties &&
   mkdir $HADOOP_DIR/logs &&  
   $HADOOP_DIR/bin/hadoop namenode -format &&
   $HADOOP_DIR/sbin/start-dfs.sh &&

--- a/.travis/scripts/install_hadoop.sh
+++ b/.travis/scripts/install_hadoop.sh
@@ -51,8 +51,8 @@ configure_passphraseless_ssh() {
 configure_hadoop() {
   configure_passphraseless_ssh &&
   cp -fr $TRAVIS_BUILD_DIR/.travis/resources/hadoop/* $HADOOP_DIR/etc/hadoop &&
-  rm -f $HADOOP_DIR/etc/hadoop/hadoop-metrics2.properties &&
   mkdir $HADOOP_DIR/logs &&  
+  export HADOOP_ROOT_LOGGER=ERROR,console &&
   $HADOOP_DIR/bin/hadoop namenode -format &&
   $HADOOP_DIR/sbin/start-dfs.sh &&
   echo "configure_hadoop successful"


### PR DESCRIPTION
We use Hadoop 2 while testing GenomicsDB, we should probably move to using Hadoop 3 while testing TileDB.