### PR TITLE
Minor: Fix deletion of array instances properly in benchmark test.

### DIFF
--- a/test/include/benchmark/tiledb_benchmark.h
+++ b/test/include/benchmark/tiledb_benchmark.h
@@ -137,25 +137,28 @@ class BenchmarkConfig: public TempDir {
   }
 
   void free_buffers() {
-    int j = 0;
-    for(auto i=0ul; i<attributes_.size(); i++, j++) {
+    for(auto i=0ul, j=0ul; i<attributes_.size(); i++) {
       if (attribute_cell_val_nums_[i] == TILEDB_VAR_NUM) {
-        delete (int64_t *)buffers_[j++];
+	delete [] (int64_t *)buffers_[i+j];
+	buffers_[i+j] = NULL;
+	j++;
       }
       switch (attribute_data_types_[i]) {
         case TILEDB_INT32:
-          delete (int32_t *)buffers_[j];
+          delete [] (int32_t *)buffers_[i+j];
           break;
         case TILEDB_INT64:
-          delete (int64_t *)buffers_[j];
+          delete [] (int64_t *)buffers_[i+j];
           break;
         case TILEDB_CHAR:
-          delete (char *)buffers_[j];
+          delete [] (char *)buffers_[i+j];
         default:
           break;
       }
+      buffers_[i+j] = NULL;
     }
-    delete (int64_t *)buffers_[j]; // coords
+    delete [] (int64_t *)buffers_[buffers_.size()-1]; // coords
+    buffers_[buffers_.size()-1] = NULL;
     buffers_.clear();
     buffer_sizes_.clear();
   }

--- a/test/inputs/valgrind.supp
+++ b/test/inputs/valgrind.supp
@@ -1,0 +1,249 @@
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   obj:/usr/lib64/libgomp.so.1.0.0
+   obj:/usr/lib64/libgomp.so.1.0.0
+   obj:/usr/lib64/libgomp.so.1.0.0
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN20GenericGrowableArray12raw_allocateEi
+   fun:_GLOBAL__sub_I_jvmtiRawMonitor.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_c1_LinearScan.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_c1_LinearScan.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_c1_LinearScan.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_c1_LinearScan.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_c1_LinearScan.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_c1_LinearScan.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN20GenericGrowableArray12raw_allocateEi
+   fun:_GLOBAL__sub_I_reflectionUtils.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_jvmtiRawMonitor.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_memoryService.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_memoryService.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_reflectionUtils.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN20GenericGrowableArray12raw_allocateEi
+   fun:_GLOBAL__sub_I_memoryService.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN20GenericGrowableArray12raw_allocateEi
+   fun:_GLOBAL__sub_I_memoryService.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEm
+   fun:_GLOBAL__sub_I_decoder.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEm
+   fun:_GLOBAL__sub_I_diagnosticFramework.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEm
+   fun:_GLOBAL__sub_I_g1CollectedHeap.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEm
+   fun:_GLOBAL__sub_I_jfrThreadSampler.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEm
+   fun:_GLOBAL__sub_I_metaspace.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEm
+   fun:_GLOBAL__sub_I_shenandoahParallelCleaning.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType4EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType4EEnwEm
+   fun:_GLOBAL__sub_I_codeCache.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}


### PR DESCRIPTION
Added the Valgrind suppressions file. This still needs work, but can be used as a starting point for refinement, almost all the suppressions are from libjvm.so!