### PR TITLE
Adding checks for all malloc/realloc calls and refactoring file_size() to return ssize_t

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -68,7 +68,13 @@ jobs:
       working-directory:  ${{env.CMAKE_BUILD_DIR}}
       run: |
         make -j4
-        TILEDB_BENCHMARK=1 make tests -j 4
+        make tests -j 4
+        export TILEDB_BENCHMARK=1
+        time test/test_sparse_array_benchmark
+        export TILEDB_DISABLE_FILE_LOCKING=1
+        time test/test_sparse_array_benchmark
+        export TILEDB_KEEP_FILE_HANDLES_OPEN=1
+        time test/test_sparse_array_benchmark
 
     - name: Cache Distributed FileSystems
       if: matrix.type == 'hdfs' || matrix.type == 'gcs' || matrix.type == 'azure'

--- a/core/include/c_api/tiledb_storage.h
+++ b/core/include/c_api/tiledb_storage.h
@@ -173,7 +173,7 @@ std::vector<std::string> get_files(const TileDB_CTX* tiledb_ctx, const std::stri
  * @param filename The name of the file whose size is to be retrieved.
  * @return The file size on success, and TILEDB_UT_ERR for error.
  */
-size_t file_size(const TileDB_CTX* tiledb_ctx, const std::string& file);
+ssize_t file_size(const TileDB_CTX* tiledb_ctx, const std::string& file);
 
 int create_file(const TileDB_CTX* tiledb_ctx, const std::string& filename, int flags, mode_t mode);
 

--- a/core/include/c_api/tiledb_storage.h
+++ b/core/include/c_api/tiledb_storage.h
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2018 Omics Data Automation Inc. and Intel Corporation
+ * @copyright Copyright (c) 2021 Omics Data Automation Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/include/misc/error.h
+++ b/core/include/misc/error.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018,2020 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018,2020-2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/include/misc/error.h
+++ b/core/include/misc/error.h
@@ -64,7 +64,7 @@
     std::string errmsg = PREFIX + "(" + __func__ + ") " + MSG;       \
     if (errno > 0) {                                                 \
       errmsg += " errno=" + std::to_string(errno) + "(" + std::string(std::strerror(errno)) + ")"; \
-    }
+    }                                                                \
     PRINT_ERROR(errmsg);                                             \
     TILEDB_MSG = errmsg;                                             \
   } while (false)

--- a/core/include/misc/error.h
+++ b/core/include/misc/error.h
@@ -59,6 +59,16 @@
     TILEDB_MSG = errmsg;                                             \
   } while (false)
 
+#define TILEDB_ERROR_WITH_ERRNO(PREFIX, MSG, TILEDB_MSG)                        \
+  do {                                                               \
+    std::string errmsg = PREFIX + "(" + __func__ + ") " + MSG;       \
+    if (errno > 0) {                                                 \
+      errmsg += " errno=" + std::to_string(errno) + "(" + std::string(std::strerror(errno)) + ")"; \
+    }
+    PRINT_ERROR(errmsg);                                             \
+    TILEDB_MSG = errmsg;                                             \
+  } while (false)
+
 #define TILEDB_ERROR(PREFIX, MSG, TILEDB_MSG)                        \
   do {                                                               \
     std::string errmsg = PREFIX + "(" + __func__ + ") " + MSG;       \

--- a/core/include/misc/utils.h
+++ b/core/include/misc/utils.h
@@ -679,7 +679,7 @@ int read_from_file(StorageFS *fs,
 int read_from_file_after_decompression(StorageFS *fs,
     const std::string& filename,
     void** buffer,
-    off_t &buffer_size,
+    size_t &buffer_size,
     const int compression);
 
 

--- a/core/include/misc/utils.h
+++ b/core/include/misc/utils.h
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2021 Omics Data Automation Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/include/misc/utils.h
+++ b/core/include/misc/utils.h
@@ -341,7 +341,7 @@ void expand_mbr(T* mbr, const T* coords, int dim_num);
  * @param filename The name of the file whose size is to be retrieved.
  * @return The file size on success, and TILEDB_UT_ERR for error.
  */
-size_t file_size(StorageFS *fs, const std::string& filename);
+ssize_t file_size(StorageFS *fs, const std::string& filename);
 
 /** Returns the names of the directories inside the input directory.
  *
@@ -679,7 +679,7 @@ int read_from_file(StorageFS *fs,
 int read_from_file_after_decompression(StorageFS *fs,
     const std::string& filename,
     void** buffer,
-    size_t &buffer_size,
+    off_t &buffer_size,
     const int compression);
 
 

--- a/core/include/storage_manager/storage_azure_blob.h
+++ b/core/include/storage_manager/storage_azure_blob.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/include/storage_manager/storage_azure_blob.h
+++ b/core/include/storage_manager/storage_azure_blob.h
@@ -68,7 +68,7 @@ class AzureBlob : public StorageFS {
   int create_file(const std::string& filename, int flags, mode_t mode);
   int delete_file(const std::string& filename);
 
-  size_t file_size(const std::string& filename);
+  ssize_t file_size(const std::string& filename);
 
   int read_from_file(const std::string& filename, off_t offset, void *buffer, size_t length);
   int write_to_file(const std::string& filename, const void *buffer, size_t buffer_size);

--- a/core/include/storage_manager/storage_fs.h
+++ b/core/include/storage_manager/storage_fs.h
@@ -78,7 +78,7 @@ class StorageFS {
   virtual int create_file(const std::string& filename, int flags, mode_t mode) = 0;
   virtual int delete_file(const std::string& filename) = 0;
 
-  virtual size_t file_size(const std::string& filename) = 0;
+  virtual ssize_t file_size(const std::string& filename) = 0;
 
   virtual int read_from_file(const std::string& filename, off_t offset, void *buffer, size_t length) = 0;
   virtual int write_to_file(const std::string& filename, const void *buffer, size_t buffer_size) = 0;

--- a/core/include/storage_manager/storage_hdfs.h
+++ b/core/include/storage_manager/storage_hdfs.h
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2018 University of California, Los Angeles and Intel Corporation
+ * @copyright Copyright (c) 2021 Omics Data Automation Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/include/storage_manager/storage_hdfs.h
+++ b/core/include/storage_manager/storage_hdfs.h
@@ -66,7 +66,7 @@ class HDFS : public StorageFS {
   int create_file(const std::string& filename, int flags, mode_t mode);
   int delete_file(const std::string& filename);
 
-  size_t file_size(const std::string& filename);
+  ssize_t file_size(const std::string& filename);
 
   int read_from_file(const std::string& filename, off_t offset, void *buffer, size_t length);
   int write_to_file(const std::string& filename, const void *buffer, size_t buffer_size);

--- a/core/include/storage_manager/storage_posixfs.h
+++ b/core/include/storage_manager/storage_posixfs.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/include/storage_manager/storage_posixfs.h
+++ b/core/include/storage_manager/storage_posixfs.h
@@ -59,7 +59,7 @@ class PosixFS : public StorageFS {
   int create_file(const std::string& filename, int flags, mode_t mode);
   int delete_file(const std::string& filename);
 
-  size_t file_size(const std::string& filename);
+  ssize_t file_size(const std::string& filename);
 
   int read_from_file(const std::string& filename, off_t offset, void *buffer, size_t length);
   int write_to_file(const std::string& filename, const void *buffer, size_t buffer_size);

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -6,7 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corp.
- * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -1851,11 +1851,11 @@ std::string current_working_dir(const TileDB_CTX* tiledb_ctx) {
    return "";
 }
 
-size_t file_size(const TileDB_CTX* tiledb_ctx, const std::string& file) {
+ssize_t file_size(const TileDB_CTX* tiledb_ctx, const std::string& file) {
   if (sanity_check_fs(tiledb_ctx)) {
     return file_size(tiledb_ctx->storage_manager_->get_config()->get_filesystem(), file);
   }
-  return 0;
+  return TILEDB_ERR;
 }
 
 inline int invoke_int_fs_fn(const TileDB_CTX* tiledb_ctx, const std::string& dir, int (*fn)(StorageFS*, const std::string&)) {

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -351,6 +351,11 @@ int move_across_filesystems(const std::string& src, const std::string& dest)
   }
   auto size = file_size(tiledb_ctx, src);
   void *buffer = malloc(size);
+  if (buffer == NULL) {
+    FINALIZE;
+    snprintf(tiledb_errmsg, TILEDB_ERRMSG_MAX_LEN, "Out-of-memory exception while allocating memory\n");
+    return TILEDB_ERR;
+  }
   int rc = read_file(tiledb_ctx, src, 0, buffer, size);
   rc |= close_file(tiledb_ctx, src);
   finalize(tiledb_ctx);

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -6,7 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2018 Omics Data Automation Inc. and Intel Corporation
- * @copyright Copyright (c) 2019-2020 Omics Data Automation Inc.
+ * @copyright Copyright (c) 2019-2021 Omics Data Automation Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -282,7 +282,7 @@ int read_entire_file(const std::string& filename, void **buffer, size_t *length)
     FINALIZE;
     return TILEDB_ERR;
   }
-  size_t size = file_size(tiledb_ctx, filename);
+  auto size = file_size(tiledb_ctx, filename);
   *length = size;
   *buffer = (char *)malloc(size+1);
   if (*buffer == NULL) {
@@ -349,7 +349,7 @@ int move_across_filesystems(const std::string& src, const std::string& dest)
     FINALIZE;
     return TILEDB_ERR;
   }
-  size_t size = file_size(tiledb_ctx, src);
+  auto size = file_size(tiledb_ctx, src);
   void *buffer = malloc(size);
   int rc = read_file(tiledb_ctx, src, 0, buffer, size);
   rc |= close_file(tiledb_ctx, src);

--- a/core/src/fragment/book_keeping.cc
+++ b/core/src/fragment/book_keeping.cc
@@ -372,14 +372,7 @@ int BookKeeping::load(StorageFS *fs) {
                          TILEDB_FILE_SUFFIX + TILEDB_GZIP_SUFFIX;
 
   // Open book-keeping file
-  auto size = file_size(fs, filename);
-  if (size <= 0) {
-    std::string errmsg = "Cannot read book-keeping file; Filesize for " + filename + " is zero or undetermined";
-    PRINT_ERROR(errmsg);
-    tiledb_bk_errmsg = TILEDB_BK_ERRMSG + errmsg;
-    return TILEDB_BK_ERR;
-  }
-
+  size_t size;
   void *buf;
   if (read_from_file_after_decompression(fs, filename, &buf, size, TILEDB_GZIP) == TILEDB_UT_ERR) {
     std::string errmsg = "Cannot read book-keeping file; Read failure for " + filename;

--- a/core/src/fragment/book_keeping.cc
+++ b/core/src/fragment/book_keeping.cc
@@ -372,7 +372,7 @@ int BookKeeping::load(StorageFS *fs) {
                          TILEDB_FILE_SUFFIX + TILEDB_GZIP_SUFFIX;
 
   // Open book-keeping file
-  size_t size = file_size(fs, filename);
+  auto size = file_size(fs, filename);
   if (size <= 0) {
     std::string errmsg = "Cannot read book-keeping file; Filesize for " + filename + " is zero or undetermined";
     PRINT_ERROR(errmsg);

--- a/core/src/fragment/book_keeping.cc
+++ b/core/src/fragment/book_keeping.cc
@@ -6,6 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2021 Omics Data Automation Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/fragment/read_state.cc
+++ b/core/src/fragment/read_state.cc
@@ -6,7 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/fragment/read_state.cc
+++ b/core/src/fragment/read_state.cc
@@ -2282,7 +2282,7 @@ int ReadState::prepare_tile_for_reading_cmp(
 
   // Find file offset where the tile begins
   off_t file_offset = tile_offsets[attribute_id_real][tile_i];
-  off_t file_size = ::file_size(array_->config()->get_filesystem(), filename);
+  auto file_size = ::file_size(array_->config()->get_filesystem(), filename);
   size_t tile_compressed_size = 
       (tile_i == tile_num-1) 
           ? file_size - tile_offsets[attribute_id_real][tile_i] 
@@ -2428,7 +2428,7 @@ int ReadState::prepare_tile_for_reading_var_cmp(
 
   // Find file offset where the tile begins
   off_t file_offset = tile_offsets[attribute_id][tile_i];
-  off_t file_size = ::file_size(array_->config()->get_filesystem(), filename);
+  auto file_size = ::file_size(array_->config()->get_filesystem(), filename);
   size_t tile_compressed_size = 
       (tile_i == tile_num-1) ? file_size - tile_offsets[attribute_id][tile_i]
                              : tile_offsets[attribute_id][tile_i+1] - 

--- a/core/src/fragment/write_state.cc
+++ b/core/src/fragment/write_state.cc
@@ -6,7 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/fragment/write_state.cc
+++ b/core/src/fragment/write_state.cc
@@ -443,12 +443,18 @@ int WriteState::write_file_buffers() {
       rc = file_buffer_[i]->finalize() || rc;
       delete file_buffer_[i];
       file_buffer_[i] = NULL;
+    } else {
+      rc = close_file(fs_, construct_filename(i, false)) || rc;
     }
+
     if (file_var_buffer_[i] != NULL) {
       rc = file_var_buffer_[i]->finalize() || rc;
       delete file_var_buffer_[i];
       file_var_buffer_[i] = NULL;
+    } else {
+      rc = close_file(fs_, construct_filename(i, false)) || rc;
     }
+
     if (rc) {
       std::string errmsg = "Could not finalize files from storage buffers";
       PRINT_ERROR(errmsg);

--- a/core/src/fragment/write_state.cc
+++ b/core/src/fragment/write_state.cc
@@ -452,7 +452,7 @@ int WriteState::write_file_buffers() {
       delete file_var_buffer_[i];
       file_var_buffer_[i] = NULL;
     } else {
-      rc = close_file(fs_, construct_filename(i, false)) || rc;
+      rc = close_file(fs_, construct_filename(i, true)) || rc;
     }
 
     if (rc) {

--- a/core/src/misc/utils.cc
+++ b/core/src/misc/utils.cc
@@ -6,7 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2019, 2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/misc/utils.cc
+++ b/core/src/misc/utils.cc
@@ -939,7 +939,7 @@ int read_from_file(StorageFS *fs,
 #define windowBits 15
 #define GZIP_ENCODING 16
 
-int read_from_file_after_decompression(StorageFS *fs, const std::string& filename, void** buffer, off_t &buffer_size, const int compression) {
+int read_from_file_after_decompression(StorageFS *fs, const std::string& filename, void** buffer, size_t &buffer_size, const int compression) {
   switch (compression) {
     case TILEDB_GZIP:
     case TILEDB_NO_COMPRESSION:
@@ -950,14 +950,13 @@ int read_from_file_after_decompression(StorageFS *fs, const std::string& filenam
   }
   
   auto size = fs->file_size(filename);
-  if (size <= 0) {
+  if (size == TILEDB_FS_ERR || size == 0) {
     UTILS_PATH_ERROR("Cannot read file into buffer as it does not exist or is empty", filename);
     return TILEDB_UT_ERR;
   }
   unsigned char *in = (unsigned char *)malloc(size);
   if (in == NULL) {
-    std::string errmsg = "Cannot read file into buffer; Mem allocation error for filesize=" + size;
-    UTILS_PATH_ERROR(errmsg, filename);
+    UTILS_PATH_ERROR( "Cannot read file into buffer; Mem allocation error for filesize=" + std::to_string(size), filename);
     return TILEDB_UT_ERR;
   }
 

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -302,7 +302,7 @@ int AzureBlob::delete_file(const std::string& filename) {
   return TILEDB_FS_OK;
 }
 
-size_t AzureBlob::file_size(const std::string& filename) {
+ssize_t AzureBlob::file_size(const std::string& filename) {
   auto blob_property = bc->get_blob_property(container_name, get_path(filename));
   if (blob_property.valid()) {
     return blob_property.size;
@@ -323,24 +323,26 @@ int AzureBlob::read_from_file(const std::string& filename, off_t offset, void *b
   std::string path = get_path(filename);
   auto bclient = reinterpret_cast<blob_client *>(bC.get());
   auto filesize = file_size(filename);
-  if (filesize >= (length + offset)) {
-    storage_outcome<void> read_result;
-    // Heuristic: if the file can be contained in a block use download_blob_to_stream(), otherwise use the parallel download_blob_to_buffer()
-    if (filesize < GRAIN_SIZE) {
-      omemstream os_buf(buffer, length);
-      read_result = bclient->download_blob_to_stream(container_name, path, offset, length, os_buf).get();
-    } else {
-      read_result = bclient->download_blob_to_buffer(container_name, path, offset, length, reinterpret_cast<char *>(buffer), std::thread::hardware_concurrency()/2).get();
-    }
-    if (!read_result.success()) {
-      AZ_BLOB_ERROR(read_result.error().message, filename);
-      return TILEDB_FS_ERR;
-    } else {
-      return TILEDB_FS_OK;
-    }
+  if (filesize <= 0) {
+    AZ_BLOB_ERROR("File does not exist or is empty", filename);
+    return TILEDB_FS_ERR;
+  } else if (filesize >= (ssize_t)length + offset) {
+    AZ_BLOB_ERROR("Cannot read past the file size", filename);
+    return TILEDB_FS_ERR;
+  }
+  storage_outcome<void> read_result;
+  // Heuristic: if the file can be contained in a block use download_blob_to_stream(), otherwise use the parallel download_blob_to_buffer()
+  if (filesize < GRAIN_SIZE) {
+    omemstream os_buf(buffer, length);
+    read_result = bclient->download_blob_to_stream(container_name, path, offset, length, os_buf).get();
   } else {
-   AZ_BLOB_ERROR("Cannot read past the file size", filename);
-   return TILEDB_FS_ERR;
+    read_result = bclient->download_blob_to_buffer(container_name, path, offset, length, reinterpret_cast<char *>(buffer), std::thread::hardware_concurrency()/2).get();
+  }
+  if (!read_result.success()) {
+    AZ_BLOB_ERROR(read_result.error().message, filename);
+    return TILEDB_FS_ERR;
+  } else {
+    return TILEDB_FS_OK;
   }
 }
 

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -326,9 +326,11 @@ int AzureBlob::read_from_file(const std::string& filename, off_t offset, void *b
   if (filesize <= 0) {
     AZ_BLOB_ERROR("File does not exist or is empty", filename);
     return TILEDB_FS_ERR;
-  } else if (filesize >= (ssize_t)length + offset) {
+  } else if (filesize < (ssize_t)length + offset) {
     AZ_BLOB_ERROR("Cannot read past the file size", filename);
     return TILEDB_FS_ERR;
+  } else if (length == 0) {
+    return TILEDB_FS_OK; // Nothing to read
   }
   storage_outcome<void> read_result;
   // Heuristic: if the file can be contained in a block use download_blob_to_stream(), otherwise use the parallel download_blob_to_buffer()

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -323,8 +323,8 @@ int AzureBlob::read_from_file(const std::string& filename, off_t offset, void *b
   std::string path = get_path(filename);
   auto bclient = reinterpret_cast<blob_client *>(bC.get());
   auto filesize = file_size(filename);
-  if (filesize <= 0) {
-    AZ_BLOB_ERROR("File does not exist or is empty", filename);
+  if (filesize == TILEDB_FS_ERR) {
+    AZ_BLOB_ERROR("File does not exist", filename);
     return TILEDB_FS_ERR;
   } else if (filesize < (ssize_t)length + offset) {
     AZ_BLOB_ERROR("Cannot read past the file size", filename);

--- a/core/src/storage_manager/storage_buffer.cc
+++ b/core/src/storage_manager/storage_buffer.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2020 Omics Data Automation Inc.
+ * @copyright Copyright (c) 2020-2021 Omics Data Automation Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/storage_manager/storage_manager.cc
+++ b/core/src/storage_manager/storage_manager.cc
@@ -455,17 +455,8 @@ int StorageManager::array_load_schema(
 
   // Initialize buffer
   ssize_t buffer_size =  file_size(fs_, filename);
-  if (buffer_size == TILEDB_UT_ERR) {
-    std::string errmsg = "Cannot load array schema; Non-existent array schema file";
-    PRINT_ERROR(errmsg);
-    tiledb_sm_errmsg = TILEDB_SM_ERRMSG + errmsg;
-    return TILEDB_SM_ERR;
-  } else if(buffer_size == 0 or buffer_size == -1) {
-    std::string errmsg = "Cannot load array schema; Empty array schema file";
-    PRINT_ERROR(errmsg);
-    tiledb_sm_errmsg = TILEDB_SM_ERRMSG + errmsg;
-    return TILEDB_SM_ERR;
-  }
+  assert(buffer_size > 0);
+
   void* buffer = malloc(buffer_size);
   if (buffer == NULL) {
     std::string errmsg = "Storage Manager memory allocation error";

--- a/core/src/storage_manager/storage_manager.cc
+++ b/core/src/storage_manager/storage_manager.cc
@@ -454,15 +454,25 @@ int StorageManager::array_load_schema(
   std::string filename = real_array_dir + "/" + TILEDB_ARRAY_SCHEMA_FILENAME;
 
   // Initialize buffer
-  size_t buffer_size =  file_size(fs_, filename);
-
-  if(buffer_size == 0) {
+  ssize_t buffer_size =  file_size(fs_, filename);
+  if (buffer_size == TILEDB_UT_ERR) {
+    std::string errmsg = "Cannot load array schema; Non-existent array schema file";
+    PRINT_ERROR(errmsg);
+    tiledb_sm_errmsg = TILEDB_SM_ERRMSG + errmsg;
+    return TILEDB_SM_ERR;
+  } else if(buffer_size == 0 or buffer_size == -1) {
     std::string errmsg = "Cannot load array schema; Empty array schema file";
     PRINT_ERROR(errmsg);
     tiledb_sm_errmsg = TILEDB_SM_ERRMSG + errmsg;
     return TILEDB_SM_ERR;
   }
   void* buffer = malloc(buffer_size);
+  if (buffer == NULL) {
+    std::string errmsg = "Storage Manager memory allocation error";
+    PRINT_ERROR(errmsg);
+    tiledb_sm_errmsg = TILEDB_SM_ERRMSG + errmsg;
+    return TILEDB_SM_ERR;
+  }
 
   // Load array schema
   if(read_from_file(fs_, filename, 0, buffer, buffer_size) == TILEDB_UT_ERR) {

--- a/core/src/storage_manager/storage_posixfs.cc
+++ b/core/src/storage_manager/storage_posixfs.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/storage_manager/storage_posixfs.cc
+++ b/core/src/storage_manager/storage_posixfs.cc
@@ -314,7 +314,7 @@ int PosixFS::delete_file(const std::string& filename) {
   return TILEDB_FS_OK;
 }
 
-size_t PosixFS::file_size(const std::string& filename) {
+ssize_t PosixFS::file_size(const std::string& filename) {
   reset_errno();
   
   if (!is_file(filename)) {

--- a/test/include/benchmark/tiledb_benchmark.h
+++ b/test/include/benchmark/tiledb_benchmark.h
@@ -137,25 +137,28 @@ class BenchmarkConfig: public TempDir {
   }
 
   void free_buffers() {
-    int j = 0;
-    for(auto i=0ul; i<attributes_.size(); i++, j++) {
+    for(auto i=0ul, j=0ul; i<attributes_.size(); i++) {
       if (attribute_cell_val_nums_[i] == TILEDB_VAR_NUM) {
-        delete (int64_t *)buffers_[j++];
+	delete [] (int64_t *)buffers_[i+j];
+	buffers_[i+j] = NULL;
+	j++;
       }
       switch (attribute_data_types_[i]) {
         case TILEDB_INT32:
-          delete (int32_t *)buffers_[j];
+          delete [] (int32_t *)buffers_[i+j];
           break;
         case TILEDB_INT64:
-          delete (int64_t *)buffers_[j];
+          delete [] (int64_t *)buffers_[i+j];
           break;
         case TILEDB_CHAR:
-          delete (char *)buffers_[j];
+          delete [] (char *)buffers_[i+j];
         default:
           break;
       }
+      buffers_[i+j] = NULL;
     }
-    delete (int64_t *)buffers_[j]; // coords
+    delete [] (int64_t *)buffers_[buffers_.size()-1]; // coords
+    buffers_[buffers_.size()-1] = NULL;
     buffers_.clear();
     buffer_sizes_.clear();
   }

--- a/test/inputs/valgrind.supp
+++ b/test/inputs/valgrind.supp
@@ -1,0 +1,249 @@
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   obj:/usr/lib64/libgomp.so.1.0.0
+   obj:/usr/lib64/libgomp.so.1.0.0
+   obj:/usr/lib64/libgomp.so.1.0.0
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN20GenericGrowableArray12raw_allocateEi
+   fun:_GLOBAL__sub_I_jvmtiRawMonitor.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_c1_LinearScan.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_c1_LinearScan.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_c1_LinearScan.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_c1_LinearScan.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_c1_LinearScan.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_c1_LinearScan.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN20GenericGrowableArray12raw_allocateEi
+   fun:_GLOBAL__sub_I_reflectionUtils.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_jvmtiRawMonitor.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_memoryService.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_memoryService.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN11ResourceObjnwEmNS_15allocation_typeE10MemoryType
+   fun:_GLOBAL__sub_I_reflectionUtils.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN20GenericGrowableArray12raw_allocateEi
+   fun:_GLOBAL__sub_I_memoryService.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN20GenericGrowableArray12raw_allocateEi
+   fun:_GLOBAL__sub_I_memoryService.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEm
+   fun:_GLOBAL__sub_I_decoder.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEm
+   fun:_GLOBAL__sub_I_diagnosticFramework.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEm
+   fun:_GLOBAL__sub_I_g1CollectedHeap.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEm
+   fun:_GLOBAL__sub_I_jfrThreadSampler.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEm
+   fun:_GLOBAL__sub_I_metaspace.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType7EEnwEm
+   fun:_GLOBAL__sub_I_shenandoahParallelCleaning.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_ZN2os6mallocEm10MemoryTypeRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType4EEnwEmRK15NativeCallStack
+   fun:_ZN8CHeapObjIL10MemoryType4EEnwEm
+   fun:_GLOBAL__sub_I_codeCache.cpp
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.17.so
+}

--- a/test/src/misc/test_utils.cc
+++ b/test/src/misc/test_utils.cc
@@ -6,7 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2018-2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2019,2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -531,44 +531,59 @@ TEST_CASE("Tests RLE compression (coordinates, column-major cell order)", "[test
   CHECK_FALSE(memcmp(input, decompressed, input_size));
 }
 
-TEST_CASE("Test utils file system operations", "[test_utils_fs]") {
+TEST_CASE_METHOD(TempDir, "Test utils file system operations", "[test_utils_fs]") {
   PosixFS test_fs;
   PosixFS *fs = &test_fs;
   
-  char *temp_dir = strdup("tiledb_test_XXXXXX");
-  if (!mkstemp(temp_dir)) {
-    CHECK(create_dir(fs, "/non-existent-dir/dir"));
-    CHECK(create_file(fs, "/non-existent-dir/file", 0, 0));
-    CHECK(write_to_file(fs, "/non-existent-dir/file", NULL, 0));
-    CHECK(read_from_file(fs, "/non-existent-dir/file", 0, NULL, 0));
-    CHECK(sync_path(fs, "/non-existent-dir/file"));
-    CHECK(delete_file(fs, "/non-existent-dir/file"));
-    CHECK(delete_dir(fs, "/non-existent-dir/dir"));
-    CHECK(move_path(fs, "/non-existent-dir/old", "/non-existent-dir/new"));
+  std::string temp_dir = get_temp_dir()+"/temp";
+  CHECK(create_dir(fs, "/non-existent-dir/dir") == TILEDB_UT_ERR);
+  CHECK(create_file(fs, "/non-existent-dir/file", 0, 0) == TILEDB_UT_ERR);
+  CHECK(write_to_file(fs, "/non-existent-dir/file", "Hello", 6) == TILEDB_UT_ERR);
+  char check_str[6];
+  CHECK(read_from_file(fs, "/non-existent-dir/file", 0, &check_str[0], 6) == TILEDB_UT_ERR);
+  CHECK(!sync_path(fs, "/non-existent-dir/file")); // This is OK for an non-existent path
+  CHECK(delete_file(fs, "/non-existent-dir/file") == TILEDB_UT_ERR);
+  CHECK(delete_dir(fs, "/non-existent-dir/dir") == TILEDB_UT_ERR);
+  CHECK(move_path(fs, "/non-existent-dir/old", "/non-existent-dir/new") == TILEDB_UT_ERR);
 
-    CHECK(!create_dir(fs, temp_dir));
-    CHECK(is_dir(fs, temp_dir));
+  CHECK(!create_dir(fs, temp_dir));
+  CHECK(is_dir(fs, temp_dir));
 
-    const std::string path = std::string(temp_dir)+"/foo";
-    CHECK(!create_file(fs, path,  O_WRONLY|O_CREAT,  S_IRWXU));
-    CHECK(is_file(fs, path));
-    CHECK(!write_to_file(fs, path, "Hello", 6));
-    char check_str[6];
-    CHECK(!read_from_file(fs, path, 0, &check_str[0], 6));
-    CHECK(file_size(fs, &check_str[0]) == 5);
-    CHECK(!sync_path(fs, path));
+  const std::string path = temp_dir+"/foo";
+  CHECK(!create_file(fs, path,  O_WRONLY|O_CREAT,  S_IRWXU));
+  CHECK(is_file(fs, path));
+  CHECK(!write_to_file(fs, path, "Hello", 6));
+  CHECK(!sync_path(fs, path));
+  CHECK(!read_from_file(fs, path, 0, &check_str[0], 6));
+  CHECK(file_size(fs, path) == 6);
+  CHECK(strcmp(&check_str[0], "Hello") == 0);
 
-    const std::string new_path = std::string(temp_dir)+"/new";
-    CHECK(!move_path(fs, path, new_path));
-    CHECK(!is_file(fs, new_path));
-    CHECK(!delete_file(fs, new_path));
-    CHECK(!delete_dir(fs, temp_dir));
-  }
+  const std::string new_path = temp_dir+"/new";
+  CHECK(!move_path(fs, path, new_path));
+  CHECK(is_file(fs, new_path));
+  CHECK(file_size(fs, new_path) == 6);
+  CHECK(!delete_file(fs, new_path));
 
-  // Cleanup temporary dir if it still exists
-  std::string cleanup = std::string("rm -fr ") + temp_dir;
-  system(cleanup.c_str());
-  free(temp_dir);
+  char *buffer;
+  size_t buffer_length;
+
+  CHECK(write_to_file_after_compression(fs, "/non-existent-file", "Hello", 6, TILEDB_NO_COMPRESSION) == TILEDB_UT_ERR);
+  CHECK(write_to_file_after_compression(fs, "/non-existent-file", "Hello", 6, TILEDB_GZIP) == TILEDB_UT_ERR);
+  CHECK(read_from_file_after_decompression(fs, "/non-existent-file", (void **)(&buffer), buffer_length, TILEDB_NO_COMPRESSION) == TILEDB_UT_ERR);
+  CHECK(read_from_file_after_decompression(fs, "/non-existent-file", (void **)(&buffer), buffer_length, TILEDB_GZIP) == TILEDB_UT_ERR);
+  
+  const std::string compressed_file = temp_dir+"/compressed_foo";
+  CHECK(write_to_file_after_compression(fs, "/non-existent-file", "Hello", 6, 1000) == TILEDB_UT_ERR); // Unsupported type
+  REQUIRE(!write_to_file_after_compression(fs, compressed_file, "Hello", 6, TILEDB_GZIP));
+  CHECK(!close_file(fs, compressed_file));
+ 
+  CHECK(read_from_file_after_decompression(fs, compressed_file, (void **)(&buffer), buffer_length, 1000) == TILEDB_UT_ERR); // Unsupported type
+  CHECK(!read_from_file_after_decompression(fs, compressed_file, (void **)(&buffer), buffer_length, TILEDB_GZIP));
+  CHECK(buffer_length == 6);
+  CHECK(!strcmp(buffer, "Hello"));
+  free(buffer);
+
+  CHECK(!delete_dir(fs, temp_dir));
 }
 
 TEST_CASE("Test empty value concept", "[empty_cell_val]") {

--- a/test/src/storage_manager/test_posixfs.cc
+++ b/test/src/storage_manager/test_posixfs.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2020 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/src/storage_manager/test_posixfs.cc
+++ b/test/src/storage_manager/test_posixfs.cc
@@ -193,7 +193,7 @@ TEST_CASE_METHOD(PosixFSTestFixture, "Test PosixFS large read/write file", "[rea
     return;
   }
   test_dir += "read_write_large";
-  size_t size = ((size_t)TILEDB_UT_MAX_WRITE_COUNT)*4;
+  ssize_t size = (ssize_t)TILEDB_UT_MAX_WRITE_COUNT*4;
   void *buffer = malloc(size);
   if (buffer) {
     memset(buffer, 'B', size);
@@ -357,7 +357,7 @@ TEST_CASE("Test writing with keeps file descriptors open until explicitly closed
   for (int i=0; i<n_iter; i++) {
     CHECK_RC(fs.write_to_file(test_dir+"/foo", "hello", 6), TILEDB_FS_OK);
     REQUIRE(fs.is_file(test_dir+"/foo"));
-    CHECK(fs.file_size(test_dir+"/foo") == (size_t)(6*(i+1)));
+    CHECK(fs.file_size(test_dir+"/foo") == 6*(i+1));
   }
   CHECK_RC(fs.close_file(test_dir+"/foo"), TILEDB_FS_OK);
 
@@ -365,7 +365,7 @@ TEST_CASE("Test writing with keeps file descriptors open until explicitly closed
   
   buffer = realloc(buffer, 6*n_iter);
   CHECK_RC(fs1.read_from_file(test_dir+"/foo", 0, buffer, 6*n_iter), TILEDB_FS_OK);
-  CHECK(fs1.file_size(test_dir+"/foo") == (size_t)(6*n_iter));
+  CHECK(fs1.file_size(test_dir+"/foo") == 6*n_iter);
   CHECK_RC(fs1.delete_file(test_dir+"/foo"), TILEDB_FS_OK);
   
   // Try closing non-existent file
@@ -397,9 +397,24 @@ TEST_CASE("Test reading/writing with keep file handles open set for write and un
   for (int i=0; i<n_iter; i++) {
     CHECK_RC(fs.write_to_file(test_dir+"/foo", "hello", 6), TILEDB_FS_OK);
     REQUIRE(fs.is_file(test_dir+"/foo"));
-    CHECK(fs.file_size(test_dir+"/foo") == (size_t)(6*(i+1)));
+    CHECK(fs.file_size(test_dir+"/foo") == 6*(i+1));
   }
   CHECK_RC(fs.close_file(test_dir+"/foo"), TILEDB_FS_OK);
+
+  // Perform some writes and sync the file. This should log an error but complete successfully
+  PosixFS *fs_sync = new PosixFS();
+  CHECK_RC(fs_sync->write_to_file(test_dir+"/foo_sync", "hello", 6), TILEDB_FS_OK);
+  REQUIRE(fs_sync->is_file(test_dir+"/foo_sync"));
+  CHECK(fs_sync->file_size(test_dir+"/foo_sync") == 6);
+  CHECK_RC(fs_sync->sync_path(test_dir+"/foo"), TILEDB_FS_OK);
+  delete fs_sync;
+  
+  // Perform some writes and do not close/sync the file. This should log an error but complete successfully
+  PosixFS *fs_no_close = new PosixFS();
+  CHECK_RC(fs_no_close->write_to_file(test_dir+"/foo_no_close", "hello", 6), TILEDB_FS_OK);
+  REQUIRE(fs_no_close->is_file(test_dir+"/foo_no_close"));
+  CHECK(fs_no_close->file_size(test_dir+"/foo_no_close") == 6);
+  delete fs_no_close;
 
   unsetenv("TILEDB_KEEP_FILE_HANDLES_OPEN");
 
@@ -407,7 +422,7 @@ TEST_CASE("Test reading/writing with keep file handles open set for write and un
   
   void *buffer = malloc(6*n_iter);
   CHECK_RC(fs1.read_from_file(test_dir+"/foo", 0, buffer, 6*n_iter), TILEDB_FS_OK);
-  CHECK(fs1.file_size(test_dir+"/foo") == (size_t)(6*n_iter));
+  CHECK(fs1.file_size(test_dir+"/foo") == 6*n_iter);
   CHECK_RC(fs1.delete_file(test_dir+"/foo"), TILEDB_FS_OK);
   
   // Try closing non-existent file


### PR DESCRIPTION
Adding checks for all malloc/realloc calls to figure out memory issues at the point of occurrence.
Refactoring file_size() to return ssize_t to allow for return values of -1.
Also, explicitly closing files while writing out attribute files in fragments as that got reversed in #72.

