### PR TITLE
Adding benchmark tests for s3/minio

### DIFF
--- a/.github/scripts/run_dfs_tests.sh
+++ b/.github/scripts/run_dfs_tests.sh
@@ -24,7 +24,13 @@ setup_azurite() {
   export AZURE_BLOB_ENDPOINT="https://127.0.0.1:10000/devstoreaccount1"
 }
 
-make -j4 && make test_tiledb_utils && make test_azure_blob_storage && make test_s3_storage && make examples && cd examples
+make -j4 &&
+make test_tiledb_utils &&
+make test_azure_blob_storage &&
+make test_sparse_array_benchmark &&
+make test_s3_storage &&
+make examples &&
+cd examples
 
 TEST=github_test_$RANDOM
 if [[ $INSTALL_TYPE == hdfs ]]; then
@@ -54,8 +60,10 @@ elif [[ $INSTALL_TYPE == azurite ]]; then
   $GITHUB_WORKSPACE/examples/run_examples.sh "az://test@devstoreaccount1.blob.core.windows.net/$TEST"
 
 elif [[ $INSTALL_TYPE == aws ]]; then
-  echo "Testing aws type"
+  TILEDB_BENCHMARK=1
+  tiledb_utils_tests "s3://github-actions-1/$TEST" &&
   $CMAKE_BUILD_DIR/test/test_s3_storage --test-dir s3://github-actions-1/$TEST &&
+  $CMAKE_BUILD_DIR/test/test_sparse_array_benchmark --test-dir s3://github-actions-1/$TEST &&
   $GITHUB_WORKSPACE/examples/run_examples.sh s3://github-actions-1/$TEST
 
 elif [[  $INSTALL_TYPE == minio ]]; then

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu-18.04, macOS-10.15]
         # All supported types
         # type: [basic, basic-codec, hdfs, gcs, azure, azurite, aws, minio]
-        type: [basic, basic-codec, hdfs, azurite, aws, minio]
+        type: [basic, basic-codec, hdfs, gcs, azurite, aws, minio]
         exclude:
           - os: macos-10.15
             type: basic-codec
@@ -34,8 +34,8 @@ jobs:
             type: azure
           - os: macos-10.15
             type: azurite
-          - os: macos-10.15
-            type: aws
+            # - os: macos-10.15
+            #   type: aws
           - os: macos-10.15
             type: minio
 

--- a/cmake/Modules/FindS3Client.cmake
+++ b/cmake/Modules/FindS3Client.cmake
@@ -111,6 +111,11 @@ elseif(NOT AWSSDK_FOUND)
                 INTERFACE_INCLUDE_DIRECTORIES ${AWSSDK_INCLUDE_DIR})
     list(APPEND AWSSDK_LINK_LIBRARIES ${_AWSSDK_TARGET_NAME})
   endforeach()
+  if(APPLE)
+    # AWSSDK has some sort of transitive dependency on CoreFoundation,
+    # add this explicitly even though CMAKE_FIND_FRAMEWORK is set to LAST
+    list(APPEND AWSSDK_LINK_LIBRARIES "-framework CoreFoundation")
+  endif()
   add_dependencies(aws-cpp-sdk-s3 awssdk-ep)
   message(STATUS "To be built AWS SDK headers: ${AWSSDK_INCLUDE_DIR}")
   message(STATUS "To be built AWS SDK libraries: ${AWSSDK_LINK_LIBRARIES}")

--- a/core/include/fragment/read_state.h
+++ b/core/include/fragment/read_state.h
@@ -416,6 +416,10 @@ class ReadState {
   /** Internal buffers associated with the attribute files */
   std::vector<StorageBuffer *> file_buffer_;
   std::vector<StorageBuffer *> file_var_buffer_;
+
+  /** Cache attribute filesizes for fragment */
+  std::vector<ssize_t> file_size_;
+  std::vector<ssize_t> file_var_size_;
   
   /** Compression per attribute */
   std::vector<Codec *> codec_;
@@ -427,8 +431,7 @@ class ReadState {
   std::vector<int64_t> fetched_tile_;
   /** The fragment the read state belongs to. */
   const Fragment* fragment_;
-  /** Keeps track of whether each attribute is empty or not. */
-  std::vector<bool> is_empty_attribute_;
+
   /** 
    * Last investigated tile coordinates. Applicable only to **sparse** fragments
    * for **dense** arrays.
@@ -521,7 +524,10 @@ class ReadState {
   /*          PRIVATE METHODS          */
   /* ********************************* */
 
-  std::string construct_filename(int attribute_id, bool is_var);
+  /**
+   * Helper method to construct filename for given attribute
+   */
+  std::string construct_filename(int attribute_id, bool is_var=false);
 
   /**
    * Resets all internal buffers associated with attribute files.

--- a/core/include/storage_manager/storage_s3.h
+++ b/core/include/storage_manager/storage_s3.h
@@ -85,7 +85,6 @@ class S3 : public StorageCloudFS {
  protected:
   std::string bucket_name_;
  
-  Aws::SDKOptions options_;
   std::shared_ptr<Aws::S3::S3Client> client_;
   std::mutex write_map_mtx_;
   typedef struct multipart_upload_info_t {

--- a/core/src/fragment/read_state.cc
+++ b/core/src/fragment/read_state.cc
@@ -130,16 +130,16 @@ ReadState::ReadState(
 
   compute_tile_search_range();
 
-  std::string fragment_name = fragment_->fragment_name();
-  std::string filename;
-  // Check empty attributes
-  is_empty_attribute_.resize(attribute_num_+1);
+  // Cache file sizes per attribute+coords
+  file_size_.resize(attribute_num_+1);
+  file_var_size_.resize(attribute_num_+1);
+  StorageFS *fs = array_->config()->get_filesystem();
   for(int i=0; i<attribute_num_+1; ++i) {
-    filename = 
-        fragment_name + "/" + array_schema_->attribute(i) + TILEDB_FILE_SUFFIX;
-    is_empty_attribute_[i] = !is_file(array_->config()->get_filesystem(), filename);
+    file_size_[i] = fs->file_size(construct_filename(i));
+    file_var_size_[i] = fs->file_size(construct_filename(i, /*is_var*/true));
   }
 
+  // Setup file buffers for buffered reading per attribute+coords
   file_buffer_.resize(attribute_num_+1);
   file_var_buffer_.resize(attribute_num_+1);
   reset_file_buffers();
@@ -1797,7 +1797,7 @@ bool ReadState::is_empty_attribute(int attribute_id) const {
   if(attribute_id == attribute_num_ + 1) 
     attribute_id = attribute_num_;
 
-  return is_empty_attribute_[attribute_id];
+  return file_size_[attribute_id] == TILEDB_FS_ERR;
 }
 
 int ReadState::map_tile_from_file_cmp(
@@ -2275,14 +2275,10 @@ int ReadState::prepare_tile_for_reading_cmp(
   if(tiles_[attribute_id] == NULL) 
     tiles_[attribute_id] = malloc(full_tile_size);
 
-  // Prepare attribute file name
-  std::string filename = fragment_->fragment_name() + "/" +
-                         array_schema_->attribute(attribute_id_real) +
-                         TILEDB_FILE_SUFFIX;
-
   // Find file offset where the tile begins
   off_t file_offset = tile_offsets[attribute_id_real][tile_i];
-  auto file_size = ::file_size(array_->config()->get_filesystem(), filename);
+  auto file_size = file_size_[attribute_id_real];
+  assert(file_size != TILEDB_FS_ERR);
   size_t tile_compressed_size = 
       (tile_i == tile_num-1) 
           ? file_size - tile_offsets[attribute_id_real][tile_i] 
@@ -2421,14 +2417,10 @@ int ReadState::prepare_tile_for_reading_var_cmp(
 
   // ========== Get tile with variable cell offsets ========== //
 
-  // Prepare attribute file name
-  std::string filename = fragment_->fragment_name() + "/" +
-             array_schema_->attribute(attribute_id) +
-             TILEDB_FILE_SUFFIX;
-
   // Find file offset where the tile begins
   off_t file_offset = tile_offsets[attribute_id][tile_i];
-  auto file_size = ::file_size(array_->config()->get_filesystem(), filename);
+  auto file_size = file_size_[attribute_id];
+  assert(file_size != TILEDB_FS_ERR);
   size_t tile_compressed_size = 
       (tile_i == tile_num-1) ? file_size - tile_offsets[attribute_id][tile_i]
                              : tile_offsets[attribute_id][tile_i+1] - 
@@ -2489,14 +2481,10 @@ int ReadState::prepare_tile_for_reading_var_cmp(
 
   // ========== Get variable tile ========== //
 
-  // Prepare variable attribute file name
-  filename = fragment_->fragment_name() + "/" +
-             array_schema_->attribute(attribute_id) + "_var" +
-             TILEDB_FILE_SUFFIX;
-
   // Calculate offset and compressed tile size
   file_offset = tile_var_offsets[attribute_id][tile_i];
-  file_size = ::file_size(array_->config()->get_filesystem(), filename);
+  file_size = file_var_size_[attribute_id];
+  assert(file_size != TILEDB_FS_ERR);
   tile_compressed_size = 
       (tile_i == tile_num-1) ? file_size-tile_var_offsets[attribute_id][tile_i]
                           : tile_var_offsets[attribute_id][tile_i+1] - 
@@ -2631,16 +2619,16 @@ int ReadState::prepare_tile_for_reading_var_cmp_none(
   off_t end_tile_var_offset = 0;
   size_t tile_var_size;
   
-  if(tile_i != tile_num - 1) { // Not the last tile
+  if(tile_i != tile_num - 1) {
+    // Not the last tile
     if (read_segment(attribute_id, false, file_offset + full_tile_size, 
              &end_tile_var_offset, TILEDB_CELL_VAR_OFFSET_SIZE) == TILEDB_RS_ERR) {
       return TILEDB_RS_ERR;
     }
     tile_var_size = end_tile_var_offset - tile_s[0];
-  } else {                  // Last tile
-    // Prepare variable attribute file name
-    std::string filename = fragment_->fragment_name() + "/" + array_schema_->attribute(attribute_id) + "_var" + TILEDB_FILE_SUFFIX;
-    tile_var_size = file_size(array_->config()->get_filesystem(), filename) - tile_s[0];
+  } else {
+    // Last tile
+    tile_var_size = file_var_size_[attribute_id] - tile_s[0];
   }
 
   // Read tile from file

--- a/core/src/storage_manager/storage_posixfs.cc
+++ b/core/src/storage_manager/storage_posixfs.cc
@@ -318,7 +318,6 @@ ssize_t PosixFS::file_size(const std::string& filename) {
   reset_errno();
   
   if (!is_file(filename)) {
-    POSIX_ERROR("Cannot get file size for paths that are not files", filename);
     return TILEDB_FS_ERR;
   }
   

--- a/core/src/storage_manager/storage_s3.cc
+++ b/core/src/storage_manager/storage_s3.cc
@@ -347,7 +347,7 @@ int S3::read_from_file(const std::string& filename, off_t offset, void *buffer, 
   Aws::S3::Model::GetObjectRequest request;
   request.SetBucket(bucket_name_);
   request.SetKey(to_aws_string(get_path(filename)));
-  request.SetRange(to_aws_string("bytes=" + std::to_string(offset) + "-" + std::to_string(length-1)));
+  request.SetRange(to_aws_string("bytes=" + std::to_string(offset) + "-" + std::to_string(offset+length-1)));
   request.SetResponseStreamFactory([buffer, length]() {
       unsigned char* buf = reinterpret_cast<unsigned char*>(const_cast<void*>(buffer));
       auto stream_buffer = Aws::New<Aws::Utils::Stream::PreallocatedStreamBuf>(CLASS_TAG, buf, length);

--- a/test/inputs/benchmark.config
+++ b/test/inputs/benchmark.config
@@ -60,9 +60,9 @@ Offsets_Compression_Levels=0,-1,0,0
 #Optional - Default is 0 - allow TileDB choose an appropriate capacity
 Cells_Per_Tile=1000
 #Optional - Default is 1024
-Cells_To_Write=10000000
+#Cells_To_Write=10000000
 #Optional - Default is 1024
-Cells_To_Read=10000000
+#Cells_To_Read=10000000
 
 # Optional - Default is 1(True)
 Print_Human_Readable_Sizes=1

--- a/test/src/storage_manager/test_s3_storage.cc
+++ b/test/src/storage_manager/test_s3_storage.cc
@@ -100,8 +100,8 @@ TEST_CASE_METHOD(S3TestFixture, "Test S3 real_dir", "[real_dir]") {
   CHECK(s3_instance->real_dir("xxx").compare(s3_instance->current_dir()+"/xxx") == 0);
   CHECK(s3_instance->real_dir("xxx/yyy").compare(s3_instance->current_dir()+"/xxx/yyy") == 0);
   CHECK(s3_instance->real_dir("/xxx/yyy").compare("xxx/yyy") == 0);
-  s3_uri test_url(get_test_dir());
-  CHECK(s3_instance->real_dir(get_test_dir()).compare(test_url.path()) == 0);
+  s3_uri test_uri(get_test_dir());
+  CHECK(s3_instance->real_dir(get_test_dir()).compare(test_uri.path().substr(1)) == 0);
   CHECK_THROWS(s3_instance->real_dir("xxx://yyy"));
 }
 


### PR DESCRIPTION
Fix bug in S3::real_dir() 

Aws::InitApi() and Aws::ShutdownApi() can pretty much be called only once in the beginning and once in the end. See https://github.com/aws/aws-sdk-cpp/issues/1067#issuecomment-463843051. For now, ignoring Aws::ShutdownApi() while closing, may be causing a small memory leak. But, we need to figure out how to handle this in a better way.
Should we introduce an overall `tiledb_init()` and `tiledb_finalize()` just to invoke `Aws::InitApi()` and `Aws::ShutdownApi()` that GenomicsDB can perhaps invoke right in the beginning and in the end?

Add `benchmark` and `test_tiledb_utils tests` to s3 actions. Lowered the number of cells read/write to 1024 for the benchmark tests to complete quickly. But, this is configurable via `test/inputs/benchmark.config` .