### PR TITLE
Cache attribute filesizes for performance optimization

### DIFF
--- a/core/include/fragment/read_state.h
+++ b/core/include/fragment/read_state.h
@@ -416,6 +416,10 @@ class ReadState {
   /** Internal buffers associated with the attribute files */
   std::vector<StorageBuffer *> file_buffer_;
   std::vector<StorageBuffer *> file_var_buffer_;
+
+  /** Cache attribute filesizes for fragment */
+  std::vector<ssize_t> file_size_;
+  std::vector<ssize_t> file_var_size_;
   
   /** Compression per attribute */
   std::vector<Codec *> codec_;
@@ -427,8 +431,7 @@ class ReadState {
   std::vector<int64_t> fetched_tile_;
   /** The fragment the read state belongs to. */
   const Fragment* fragment_;
-  /** Keeps track of whether each attribute is empty or not. */
-  std::vector<bool> is_empty_attribute_;
+
   /** 
    * Last investigated tile coordinates. Applicable only to **sparse** fragments
    * for **dense** arrays.
@@ -521,7 +524,10 @@ class ReadState {
   /*          PRIVATE METHODS          */
   /* ********************************* */
 
-  std::string construct_filename(int attribute_id, bool is_var);
+  /**
+   * Helper method to construct filename for given attribute
+   */
+  std::string construct_filename(int attribute_id, bool is_var=false);
 
   /**
    * Resets all internal buffers associated with attribute files.

--- a/core/src/fragment/read_state.cc
+++ b/core/src/fragment/read_state.cc
@@ -130,16 +130,16 @@ ReadState::ReadState(
 
   compute_tile_search_range();
 
-  std::string fragment_name = fragment_->fragment_name();
-  std::string filename;
-  // Check empty attributes
-  is_empty_attribute_.resize(attribute_num_+1);
+  // Cache file sizes per attribute+coords
+  file_size_.resize(attribute_num_+1);
+  file_var_size_.resize(attribute_num_+1);
+  StorageFS *fs = array_->config()->get_filesystem();
   for(int i=0; i<attribute_num_+1; ++i) {
-    filename = 
-        fragment_name + "/" + array_schema_->attribute(i) + TILEDB_FILE_SUFFIX;
-    is_empty_attribute_[i] = !is_file(array_->config()->get_filesystem(), filename);
+    file_size_[i] = fs->file_size(construct_filename(i));
+    file_var_size_[i] = fs->file_size(construct_filename(i, /*is_var*/true));
   }
 
+  // Setup file buffers for buffered reading per attribute+coords
   file_buffer_.resize(attribute_num_+1);
   file_var_buffer_.resize(attribute_num_+1);
   reset_file_buffers();
@@ -1797,7 +1797,7 @@ bool ReadState::is_empty_attribute(int attribute_id) const {
   if(attribute_id == attribute_num_ + 1) 
     attribute_id = attribute_num_;
 
-  return is_empty_attribute_[attribute_id];
+  return file_size_[attribute_id] == TILEDB_FS_ERR;
 }
 
 int ReadState::map_tile_from_file_cmp(
@@ -2275,14 +2275,10 @@ int ReadState::prepare_tile_for_reading_cmp(
   if(tiles_[attribute_id] == NULL) 
     tiles_[attribute_id] = malloc(full_tile_size);
 
-  // Prepare attribute file name
-  std::string filename = fragment_->fragment_name() + "/" +
-                         array_schema_->attribute(attribute_id_real) +
-                         TILEDB_FILE_SUFFIX;
-
   // Find file offset where the tile begins
   off_t file_offset = tile_offsets[attribute_id_real][tile_i];
-  auto file_size = ::file_size(array_->config()->get_filesystem(), filename);
+  auto file_size = file_size_[attribute_id_real];
+  assert(file_size != TILEDB_FS_ERR);
   size_t tile_compressed_size = 
       (tile_i == tile_num-1) 
           ? file_size - tile_offsets[attribute_id_real][tile_i] 
@@ -2421,14 +2417,10 @@ int ReadState::prepare_tile_for_reading_var_cmp(
 
   // ========== Get tile with variable cell offsets ========== //
 
-  // Prepare attribute file name
-  std::string filename = fragment_->fragment_name() + "/" +
-             array_schema_->attribute(attribute_id) +
-             TILEDB_FILE_SUFFIX;
-
   // Find file offset where the tile begins
   off_t file_offset = tile_offsets[attribute_id][tile_i];
-  auto file_size = ::file_size(array_->config()->get_filesystem(), filename);
+  auto file_size = file_size_[attribute_id];
+  assert(file_size != TILEDB_FS_ERR);
   size_t tile_compressed_size = 
       (tile_i == tile_num-1) ? file_size - tile_offsets[attribute_id][tile_i]
                              : tile_offsets[attribute_id][tile_i+1] - 
@@ -2489,14 +2481,10 @@ int ReadState::prepare_tile_for_reading_var_cmp(
 
   // ========== Get variable tile ========== //
 
-  // Prepare variable attribute file name
-  filename = fragment_->fragment_name() + "/" +
-             array_schema_->attribute(attribute_id) + "_var" +
-             TILEDB_FILE_SUFFIX;
-
   // Calculate offset and compressed tile size
   file_offset = tile_var_offsets[attribute_id][tile_i];
-  file_size = ::file_size(array_->config()->get_filesystem(), filename);
+  file_size = file_var_size_[attribute_id];
+  assert(file_size != TILEDB_FS_ERR);
   tile_compressed_size = 
       (tile_i == tile_num-1) ? file_size-tile_var_offsets[attribute_id][tile_i]
                           : tile_var_offsets[attribute_id][tile_i+1] - 
@@ -2631,16 +2619,16 @@ int ReadState::prepare_tile_for_reading_var_cmp_none(
   off_t end_tile_var_offset = 0;
   size_t tile_var_size;
   
-  if(tile_i != tile_num - 1) { // Not the last tile
+  if(tile_i != tile_num - 1) {
+    // Not the last tile
     if (read_segment(attribute_id, false, file_offset + full_tile_size, 
              &end_tile_var_offset, TILEDB_CELL_VAR_OFFSET_SIZE) == TILEDB_RS_ERR) {
       return TILEDB_RS_ERR;
     }
     tile_var_size = end_tile_var_offset - tile_s[0];
-  } else {                  // Last tile
-    // Prepare variable attribute file name
-    std::string filename = fragment_->fragment_name() + "/" + array_schema_->attribute(attribute_id) + "_var" + TILEDB_FILE_SUFFIX;
-    tile_var_size = file_size(array_->config()->get_filesystem(), filename) - tile_s[0];
+  } else {
+    // Last tile
+    tile_var_size = file_var_size_[attribute_id] - tile_s[0];
   }
 
   // Read tile from file

--- a/core/src/storage_manager/storage_posixfs.cc
+++ b/core/src/storage_manager/storage_posixfs.cc
@@ -318,7 +318,6 @@ ssize_t PosixFS::file_size(const std::string& filename) {
   reset_errno();
   
   if (!is_file(filename)) {
-    POSIX_ERROR("Cannot get file size for paths that are not files", filename);
     return TILEDB_FS_ERR;
   }
   


### PR DESCRIPTION
Cache attribute filesizes in ReadState constructor. This is low hanging fruit to eke out a little performance.

Also moved out any extraneous file size checks in the storage read_from_file() implementations. Only the azure blob store sdk does not return an error when trying to download an object beyond the range uploaded. For now, ignoring this inly for azure blob stores and will rely on the clients doing this check.