### PR TITLE
Adding macOS to test s3 and bug fix

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu-18.04, macOS-10.15]
         # All supported types
         # type: [basic, basic-codec, hdfs, gcs, azure, azurite, aws, minio]
-        type: [basic, basic-codec, hdfs, azurite, aws, minio]
+        type: [basic, basic-codec, hdfs, gcs, azurite, aws, minio]
         exclude:
           - os: macos-10.15
             type: basic-codec
@@ -34,8 +34,8 @@ jobs:
             type: azure
           - os: macos-10.15
             type: azurite
-          - os: macos-10.15
-            type: aws
+            # - os: macos-10.15
+            #   type: aws
           - os: macos-10.15
             type: minio
 

--- a/cmake/Modules/FindS3Client.cmake
+++ b/cmake/Modules/FindS3Client.cmake
@@ -111,6 +111,11 @@ elseif(NOT AWSSDK_FOUND)
                 INTERFACE_INCLUDE_DIRECTORIES ${AWSSDK_INCLUDE_DIR})
     list(APPEND AWSSDK_LINK_LIBRARIES ${_AWSSDK_TARGET_NAME})
   endforeach()
+  if(APPLE)
+    # AWSSDK has some sort of transitive dependency on CoreFoundation,
+    # add this explicitly even though CMAKE_FIND_FRAMEWORK is set to LAST
+    list(APPEND AWSSDK_LINK_LIBRARIES "-framework CoreFoundation")
+  endif()
   add_dependencies(aws-cpp-sdk-s3 awssdk-ep)
   message(STATUS "To be built AWS SDK headers: ${AWSSDK_INCLUDE_DIR}")
   message(STATUS "To be built AWS SDK libraries: ${AWSSDK_LINK_LIBRARIES}")

--- a/core/src/storage_manager/storage_s3.cc
+++ b/core/src/storage_manager/storage_s3.cc
@@ -347,7 +347,7 @@ int S3::read_from_file(const std::string& filename, off_t offset, void *buffer, 
   Aws::S3::Model::GetObjectRequest request;
   request.SetBucket(bucket_name_);
   request.SetKey(to_aws_string(get_path(filename)));
-  request.SetRange(to_aws_string("bytes=" + std::to_string(offset) + "-" + std::to_string(length-1)));
+  request.SetRange(to_aws_string("bytes=" + std::to_string(offset) + "-" + std::to_string(offset+length-1)));
   request.SetResponseStreamFactory([buffer, length]() {
       unsigned char* buf = reinterpret_cast<unsigned char*>(const_cast<void*>(buffer));
       auto stream_buffer = Aws::New<Aws::Utils::Stream::PreallocatedStreamBuf>(CLASS_TAG, buf, length);


### PR DESCRIPTION
Getting MacOS to test s3 port. Also fixed bug with the s3 port where the byte range was getting constructed in S3::read_from_file() - this bug surfaced while testing with GenomicsDB.