### PR TITLE
Cache file size rather than compute in StorageBuffer::read_segment()

### DIFF
--- a/core/include/storage_manager/storage_buffer.h
+++ b/core/include/storage_manager/storage_buffer.h
@@ -41,6 +41,9 @@ class StorageBuffer : public Buffer {
     fs_ = fs;
     filename_ = filename;
     read_only_ = is_read;
+    if (read_only_) {
+      filesize_ = fs_->file_size(filename);
+    }
   }
 
   /**
@@ -60,6 +63,5 @@ class StorageBuffer : public Buffer {
   
   StorageFS *fs_ = NULL;
   std::string filename_;
-  uint32_t num_blocks_ = 0;
-  std::vector<bool> blocks_read_;
+  ssize_t filesize_; // Relevant for only read_only
 };

--- a/core/src/fragment/read_state.cc
+++ b/core/src/fragment/read_state.cc
@@ -1224,12 +1224,12 @@ int ReadState::read_segment(int attribute_num, bool is_var, off_t offset, void *
     if (is_var) {
       assert((attribute_num < attribute_num_) && "Coords attribute cannot be variable");
       if (file_var_buffer_[attribute_num] == NULL) {
-        file_var_buffer_[attribute_num]= new StorageBuffer(fs, filename);
+        file_var_buffer_[attribute_num]= new StorageBuffer(fs, filename, true);
       }
       file_buffer = file_var_buffer_[attribute_num];
     } else {
       if (file_buffer_[attribute_num] == NULL) {
-        file_buffer_[attribute_num] = new StorageBuffer(fs, filename);
+        file_buffer_[attribute_num] = new StorageBuffer(fs, filename, true);
       }
       file_buffer = file_buffer_[attribute_num];
     }

--- a/core/src/storage_manager/storage_buffer.cc
+++ b/core/src/storage_manager/storage_buffer.cc
@@ -46,19 +46,15 @@ int StorageBuffer::read_buffer(off_t offset, void *bytes, size_t size) {
   // Nothing to do
   if (bytes == NULL || size == 0) {
     return TILEDB_BF_OK;
+  } else if (filesize_ == TILEDB_FS_ERR) {
+    return TILEDB_BF_ERR;
   }
 
-  size_t filesize = fs_->file_size(filename_);
+  size_t filesize = (size_t)filesize_;
   size_t chunk_size = fs_->get_download_buffer_size();
   if (offset + size > filesize) {
     BUFFER_PATH_ERROR("Cannot read past the filesize from buffer", filename_);
     return TILEDB_BF_ERR;  
-  }
-
-  if (buffer_ == NULL) {
-    num_blocks_ = filesize/chunk_size+1;
-    blocks_read_.resize(num_blocks_);
-    std::fill(blocks_read_.begin(), blocks_read_.end(), false);
   }
 
   if (buffer_ == NULL || !(offset>=buffer_offset_ && size<=buffer_size_)) {

--- a/test/src/storage_manager/test_azure_blob_storage.cc
+++ b/test/src/storage_manager/test_azure_blob_storage.cc
@@ -237,7 +237,7 @@ TEST_CASE_METHOD(AzureBlobTestFixture, "Test AzureBlob large read/write file", "
     CHECK_RC(azure_blob->write_to_file(test_dir+"/foo", buffer, size), TILEDB_FS_OK);
     CHECK_RC(azure_blob->sync_path(test_dir+"/foo"), TILEDB_FS_OK);
     CHECK(azure_blob->is_file(test_dir+"/foo"));
-    CHECK(azure_blob->file_size(test_dir+"/foo") == size);
+    CHECK((size_t)azure_blob->file_size(test_dir+"/foo") == size);
 
     void *buffer1 = malloc(size);
     if (buffer1) {
@@ -262,13 +262,13 @@ TEST_CASE_METHOD(AzureBlobTestFixture, "Test AzureBlob parallel operations", "[p
 
   bool complete = true;
   uint iterations = 2;
+  size_t size = 10*1024*1024;
 
   #pragma omp parallel for
   for (uint i=0; i<iterations; i++) {
     std::string filename = test_dir+"/foo"+std::to_string(i);
 
     for (auto j=0; j<2; j++) {
-      size_t size = TILEDB_UT_MAX_WRITE_COUNT;
       void *buffer = malloc(size);
       if (buffer) {
 	memset(buffer, 'X', size);
@@ -288,7 +288,7 @@ TEST_CASE_METHOD(AzureBlobTestFixture, "Test AzureBlob parallel operations", "[p
       std::string filename = test_dir+"/foo"+std::to_string(i);
       CHECK_RC(azure_blob->sync_path(filename), TILEDB_FS_OK);
       CHECK(azure_blob->is_file(filename));
-      CHECK(azure_blob->file_size(filename) == ((size_t)TILEDB_UT_MAX_WRITE_COUNT)*2);
+      CHECK((size_t)azure_blob->file_size(filename) == size*2);
     }
   }
 

--- a/test/src/storage_manager/test_s3_storage.cc
+++ b/test/src/storage_manager/test_s3_storage.cc
@@ -247,7 +247,7 @@ TEST_CASE_METHOD(S3TestFixture, "Test S3 large read/write file", "[read-write-la
     CHECK_RC(s3_instance->write_to_file(test_dir+"/foo", buffer, size), TILEDB_FS_OK);
     CHECK_RC(s3_instance->sync_path(test_dir+"/foo"), TILEDB_FS_OK);
     CHECK(s3_instance->is_file(test_dir+"/foo"));
-    CHECK(s3_instance->file_size(test_dir+"/foo") == size);
+    CHECK((size_t)s3_instance->file_size(test_dir+"/foo") == size);
 
     void *buffer1 = malloc(size);
     if (buffer1) {
@@ -272,13 +272,13 @@ TEST_CASE_METHOD(S3TestFixture, "Test S3 operations", "[parallel]") {
 
   bool complete = true;
   uint iterations = 2;
+  size_t size = 10*1024*1024;
 
   #pragma omp parallel for
   for (uint i=0; i<iterations; i++) {
     std::string filename = test_dir+"/foo"+std::to_string(i);
 
     for (auto j=0; j<2; j++) {
-      size_t size = 10*1024*1024;
       void *buffer = malloc(size);
       if (buffer) {
 	memset(buffer, 'X', size);
@@ -298,7 +298,7 @@ TEST_CASE_METHOD(S3TestFixture, "Test S3 operations", "[parallel]") {
       std::string filename = test_dir+"/foo"+std::to_string(i);
       CHECK_RC(s3_instance->sync_path(filename), TILEDB_FS_OK);
       CHECK(s3_instance->is_file(filename));
-      CHECK(s3_instance->file_size(filename) == (size_t)(10*1024*1024*2));
+      CHECK((size_t)s3_instance->file_size(filename) == size*2);
     }
   }
 


### PR DESCRIPTION
Cache filesizes rather than re-compute in StorageBuffer::read_segment(). 
Removed some dead code in StorageBuffer, we could make another pass at optimization here, but leaving it as is for now. Also, we are seeing some SIGPIPE curl issues only on `Centos` with parallel downloads/uploads on Azure Blob Storage, there is an [issue](https://github.com/Azure/azure-storage-cpplite/issues/87) open in the azure lite sdk. Some suggestion to a solution in this [PR](https://github.com/Azure/azure-storage-cpplite/pull/89). Will look into implementing a signal handler as suggested [here](https://curl.se/mail/lib-2018-12/0076.html).

Also, as part of this PR, reduced the size of  writes in test cloud filesystem operations to finish in a decent time to help with GitHub builds.