### PR TITLE
Fixes for missing ca certs on some of the Linux VMs and better file path manipulation

### DIFF
--- a/core/include/storage_manager/storage_fs.h
+++ b/core/include/storage_manager/storage_fs.h
@@ -111,7 +111,7 @@ class StorageFS {
     }
   }
 
-  std::string slashify(const std::string& path) const {
+  static inline std::string slashify(const std::string& path) {
     if (path.empty()) {
       return "/";
     } else if (path.back() != '/') {
@@ -121,12 +121,16 @@ class StorageFS {
     }
   }
 
-  std::string unslashify(const std::string& path) const {
+  static inline std::string unslashify(const std::string& path) {
     if (!path.empty() && path.back() == '/') {
       return path.substr(0, path.size()-1);
     } else {
       return path;
     }
+  }
+
+  static inline std::string append_paths(const std::string& path1, const std::string& path2) {
+    return slashify(path1) + path2;
   }
 
  protected:

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -96,18 +96,19 @@ int tiledb_ctx_init(
   // Initialize context
   *tiledb_ctx = (TileDB_CTX*) malloc(sizeof(struct TileDB_CTX));
   if(*tiledb_ctx == NULL) {
-    std::string errmsg = 
+    std::string errmsg =
         "Cannot initialize TileDB context; Failed to allocate memory "
         "space for the context";
     PRINT_ERROR(errmsg);
     strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
     return TILEDB_ERR;
   }
+  memset(*tiledb_ctx, 0, sizeof(struct TileDB_CTX));
 
   // Initialize a Config object
-  StorageManagerConfig* config = new StorageManagerConfig();
-  if(tiledb_config != NULL)
-    if (config->init(
+  StorageManagerConfig* storage_manager_config = new StorageManagerConfig();
+  if(tiledb_config != NULL) {
+    if (storage_manager_config->init(
         tiledb_config->home_, 
 #ifdef HAVE_MPI
         tiledb_config->mpi_comm_, 
@@ -115,35 +116,44 @@ int tiledb_ctx_init(
         tiledb_config->read_method_, 
         tiledb_config->write_method_,
         tiledb_config->enable_shared_posixfs_optimizations_) == TILEDB_SMC_ERR) {
-      delete config;
+      delete storage_manager_config;
+      free(*tiledb_ctx);
+      *tiledb_ctx = NULL;
       strcpy(tiledb_errmsg, tiledb_smc_errmsg.c_str());
       return TILEDB_ERR;
     }
+  }
 
   // Create storage manager
-  (*tiledb_ctx)->storage_manager_ = new StorageManager();
-  if((*tiledb_ctx)->storage_manager_->init(config) != TILEDB_SM_OK) {
+  StorageManager* storage_manager = new StorageManager();
+  if(storage_manager->init(storage_manager_config) != TILEDB_SM_OK) {
+    // No need to delete storage_manager_config as StorageManager owns it at this point
+    // See StorageManager::config_set().
+    delete storage_manager;
+    free(*tiledb_ctx);
+    *tiledb_ctx = NULL;
     strcpy(tiledb_errmsg, tiledb_sm_errmsg.c_str());
     return TILEDB_ERR;
   }
+  (*tiledb_ctx)->storage_manager_ = storage_manager;
 
   // Success
   return TILEDB_OK;
 }
 
 int tiledb_ctx_finalize(TileDB_CTX* tiledb_ctx) {
-
   // Trivial case
   if(tiledb_ctx == NULL)
     return TILEDB_OK;
 
   // Finalize storage manager
   int rc = TILEDB_OK;
-  if(tiledb_ctx->storage_manager_ != NULL)
+  if(tiledb_ctx->storage_manager_ != NULL) {
     rc = tiledb_ctx->storage_manager_->finalize();
+    delete tiledb_ctx->storage_manager_;
+  }
 
   // Clean up
-  delete tiledb_ctx->storage_manager_;
   free(tiledb_ctx);
 
   // Error

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -115,6 +115,7 @@ int tiledb_ctx_init(
         tiledb_config->read_method_, 
         tiledb_config->write_method_,
         tiledb_config->enable_shared_posixfs_optimizations_) == TILEDB_SMC_ERR) {
+      delete config;
       strcpy(tiledb_errmsg, tiledb_smc_errmsg.c_str());
       return TILEDB_ERR;
     }

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -35,6 +35,7 @@
 
 #include "tiledb_utils.h"
 #include "tiledb_storage.h"
+#include "storage_fs.h"
 
 #include <cstring>
 #include <error.h>
@@ -141,7 +142,7 @@ bool array_exists(const std::string& workspace, const std::string& array_name)
   bool exists = false;
   TileDB_CTX *tiledb_ctx;
   int rc = setup(&tiledb_ctx, workspace);
-  exists = !rc && is_array(tiledb_ctx, workspace + '/' + array_name);
+  exists = !rc && is_array(tiledb_ctx, StorageFS::append_paths(workspace, array_name));
   FINALIZE;
   return exists;
 }

--- a/core/src/fragment/book_keeping.cc
+++ b/core/src/fragment/book_keeping.cc
@@ -280,9 +280,9 @@ int BookKeeping::finalize(StorageFS *fs) {
     return TILEDB_BK_ERR;
 
   // Prepare file name 
-  std::string filename = fragment_name_ + "/" +
-                         TILEDB_BOOK_KEEPING_FILENAME + 
-                         TILEDB_FILE_SUFFIX + TILEDB_GZIP_SUFFIX;
+  std::string filename = fs->append_paths(fragment_name_,
+                                          std::string(TILEDB_BOOK_KEEPING_FILENAME) + 
+                                          TILEDB_FILE_SUFFIX + TILEDB_GZIP_SUFFIX);
 
   if(write_to_file_after_compression(fs, filename.c_str(), buffer_.get_buffer(), buffer_.get_buffer_size(), TILEDB_GZIP) == TILEDB_UT_ERR) {
     std::string errmsg =
@@ -368,9 +368,9 @@ int BookKeeping::init(const void* non_empty_domain) {
  */
 int BookKeeping::load(StorageFS *fs) {
   // Prepare file name
-  std::string filename = fragment_name_ + "/" +
-                         TILEDB_BOOK_KEEPING_FILENAME + 
-                         TILEDB_FILE_SUFFIX + TILEDB_GZIP_SUFFIX;
+  std::string filename = fs->append_paths(fragment_name_,
+                                          std::string(TILEDB_BOOK_KEEPING_FILENAME) + 
+                                          TILEDB_FILE_SUFFIX + TILEDB_GZIP_SUFFIX);
 
   // Open book-keeping file
   size_t size;

--- a/core/src/misc/utils.cc
+++ b/core/src/misc/utils.cc
@@ -307,7 +307,7 @@ int delete_file(StorageFS *fs, const std::string& filename) {
 
 int create_fragment_file(StorageFS *fs, const std::string& dir) {
   // Create the special fragment file
-  std::string filename = std::string(dir) + "/" + TILEDB_FRAGMENT_FILENAME;
+  std::string filename = fs->append_paths(dir, TILEDB_FRAGMENT_FILENAME);
   if (fs->create_file(filename, O_WRONLY | O_CREAT | O_SYNC,  S_IRWXU) == TILEDB_UT_ERR) {
     UTILS_PATH_ERROR("Failed to create fragment file", dir);
     return TILEDB_UT_ERR;
@@ -613,7 +613,7 @@ bool intersect(const std::vector<T>& v1, const std::vector<T>& v2) {
 
 bool is_array(StorageFS *fs, const std::string& dir) {
   // Check existence
-  return is_file(fs, dir + "/" + TILEDB_ARRAY_SCHEMA_FILENAME);
+  return fs->is_file(fs->append_paths(dir, TILEDB_ARRAY_SCHEMA_FILENAME));
 }
 
 template<class T>
@@ -638,17 +638,17 @@ bool is_file(StorageFS *fs, const std::string& file) {
 
 bool is_fragment(StorageFS *fs, const std::string& dir) {
   // Check existence
-  return fs->is_file(dir + '/' + TILEDB_FRAGMENT_FILENAME);
+  return fs->is_file(fs->append_paths(dir, TILEDB_FRAGMENT_FILENAME));
 }
 
 bool is_group(StorageFS *fs, const std::string& dir) {
   // Check existence
-  return fs->is_file(dir + '/' + TILEDB_GROUP_FILENAME);
+  return fs->is_file(fs->append_paths(dir, TILEDB_GROUP_FILENAME));
 }
 
 bool is_metadata(StorageFS *fs, const std::string& dir) {
   // Check existence
-  return fs->is_file(dir + '/' + TILEDB_METADATA_SCHEMA_FILENAME);
+  return fs->is_file(fs->append_paths(dir, TILEDB_METADATA_SCHEMA_FILENAME));
 }
 
 bool is_positive_integer(const char* s) {
@@ -683,7 +683,7 @@ bool is_unary_subarray(const T* subarray, int dim_num) {
 
 bool is_workspace(StorageFS *fs, const std::string& dir) {
   // Check existence
-  return fs->is_file(dir + '/' + TILEDB_WORKSPACE_FILENAME);
+  return fs->is_file(fs->append_paths(dir, TILEDB_WORKSPACE_FILENAME));
 }
 
 #ifdef HAVE_MPI

--- a/core/src/storage_manager/storage_fs.cc
+++ b/core/src/storage_manager/storage_fs.cc
@@ -74,7 +74,7 @@ std::string StorageCloudFS::get_path(const std::string& path) {
     // TODO: this is a hack for now, but should work fine with GenomicsDB.
     return pathname;
   } else {
-    return working_dir_ + '/' + pathname;
+    return append_paths(working_dir_, pathname);
   }
 }
 

--- a/core/src/storage_manager/storage_gcs.cc
+++ b/core/src/storage_manager/storage_gcs.cc
@@ -164,11 +164,12 @@ GCS::GCS(const std::string& home) {
   gcs::ChannelOptions channel_options;
   std::string ca_certs_location = locate_ca_certs();
   if (ca_certs_location.empty()) {
-    std::cerr << "CA Certs path not located" << std::endl;
+#ifdef DEBUG
+    std::cerr << "CA Certs path not located. Using defaults" << std::endl;
+#endif
   } else {
     channel_options.set_ssl_root_path(ca_certs_location);
   }
-  std::cerr << "CA Certs path=" << ca_certs_location << std::endl;
   auto client_options = gcs::ClientOptions::CreateDefaultClientOptions(channel_options);
 #else
   auto client_options = gcs::ClientOptions::CreateDefaultClientOptions();
@@ -223,9 +224,7 @@ int GCS::create_path(const std::string& path) {
   StatusOr<gcs::ObjectMetadata> object_metadata =
       client_->InsertObject(bucket_name_, get_path(path), "");
   if (!object_metadata) {
-    std::cerr << "Error inserting object " << path << " in bucket "
-              << bucket_name_ << ", status=" << object_metadata.status()
-              << std::endl;
+    GCS_ERROR1("Error inserting object into bucket", object_metadata.status(), path);
     return TILEDB_FS_ERR;
   } else {
     return TILEDB_FS_OK;

--- a/core/src/storage_manager/storage_gcs.cc
+++ b/core/src/storage_manager/storage_gcs.cc
@@ -150,7 +150,7 @@ hdfsFS gcs_connect(struct hdfsBuilder *builder, const std::string& working_dir) 
 
 
 GCS::GCS(const std::string& home) {
-   gcs_uri path_uri(home);
+  gcs_uri path_uri(home);
 
   if (path_uri.protocol().compare("gs") != 0) {
     throw std::system_error(EPROTONOSUPPORT, std::generic_category(), "GCS FS only supports gs:// URI protocols");
@@ -174,11 +174,14 @@ GCS::GCS(const std::string& home) {
   auto client_options = gcs::ClientOptions::CreateDefaultClientOptions();
 #endif
   if (!client_options) {
-    std::system_error(EIO, std::generic_category(), "Failed to create default GCS Client Options"+
-		      client_options.status().message());
+    throw std::system_error(EIO, std::generic_category(), "Failed to create default GCS Client Options. "+
+                            client_options.status().message());
   }
-  
-  client_ = gcs::Client(*client_options, gcs::StrictIdempotencyPolicy(), gcs::AlwaysRetryIdempotencyPolicy(), gcs::LimitedErrorCountRetryPolicy(20));
+  // TODO: All the Policies seem to be internal with internal visibility. Leaving them as defaults for now
+  // client_ = gcs::Client(*client_options, gcs::StrictIdempotencyPolicy(),
+  //                                        gcs::AlwaysRetryIdempotencyPolicy(),
+  //                                        gcs::LimitedErrorCountRetryPolicy(20));
+  client_ = gcs::Client(*client_options);
   if (!client_) {
     throw std::system_error(EIO, std::generic_category(), "Failed to create GCS Client"+client_.status().message());
   }

--- a/core/src/storage_manager/storage_manager.cc
+++ b/core/src/storage_manager/storage_manager.cc
@@ -451,7 +451,7 @@ int StorageManager::array_load_schema(
     return TILEDB_SM_ERR;
   }
 
-  std::string filename = real_array_dir + "/" + TILEDB_ARRAY_SCHEMA_FILENAME;
+  std::string filename = fs_->append_paths(real_array_dir, TILEDB_ARRAY_SCHEMA_FILENAME);
 
   // Initialize buffer
   ssize_t buffer_size =  file_size(fs_, filename);
@@ -839,7 +839,7 @@ int StorageManager::metadata_create(const ArraySchema* array_schema) const {
     return TILEDB_SM_ERR;
   }
 
-  std::string filename = dir + "/" + TILEDB_METADATA_SCHEMA_FILENAME;
+  std::string filename = fs_->append_paths(dir, TILEDB_METADATA_SCHEMA_FILENAME);
 
   // Serialize metadata schema
   void* array_schema_bin;
@@ -888,8 +888,7 @@ int StorageManager::metadata_load_schema(
   }
 
   // Open array schema file 
-  std::string filename = 
-      real_metadata_dir + "/" + TILEDB_METADATA_SCHEMA_FILENAME;
+  std::string filename = fs_->append_paths(real_metadata_dir, TILEDB_METADATA_SCHEMA_FILENAME);
 
   // Initialize buffer
   ssize_t buffer_size = file_size(fs_, filename);
@@ -1494,7 +1493,7 @@ int StorageManager::array_store_schema(
     const std::string& dir, 
     const ArraySchema* array_schema) const {
   // Array schema file
-  std::string filename = dir + "/" + TILEDB_ARRAY_SCHEMA_FILENAME;
+  std::string filename = fs_->append_paths(dir, TILEDB_ARRAY_SCHEMA_FILENAME);
   if (is_file(fs_, filename) && delete_file(fs_, filename) == TILEDB_UT_ERR) {
     std::string errmsg = 
         std::string("Cannot store schema as existing file cannot be deleted");
@@ -1668,8 +1667,7 @@ int StorageManager::consolidation_finalize(
   int fragment_num = old_fragment_names.size();
   for(int i=0; i<fragment_num; ++i) {
     // Delete special fragment file inside the fragment directory
-    std::string old_fragment_filename = 
-        old_fragment_names[i] + "/" + TILEDB_FRAGMENT_FILENAME;
+    std::string old_fragment_filename = fs_->append_paths(old_fragment_names[i], TILEDB_FRAGMENT_FILENAME);
     if(delete_file(fs_, old_fragment_filename)) {
       std::string errmsg = 
           std::string("Cannot remove fragment file during "
@@ -1691,7 +1689,7 @@ int StorageManager::consolidation_finalize(
 
 int StorageManager::create_group_file(const std::string& group) const {
   // Create file
-  std::string filename = group + "/" + TILEDB_GROUP_FILENAME;
+  std::string filename = fs_->append_paths(group, TILEDB_GROUP_FILENAME);
   if(create_file(fs_, filename,  O_WRONLY | O_CREAT | O_SYNC, S_IRWXU) == TILEDB_FS_ERR) {
     std::string errmsg = std::string("Failed to create group file");
     PRINT_ERROR(errmsg);
@@ -1705,7 +1703,7 @@ int StorageManager::create_group_file(const std::string& group) const {
 
 int StorageManager::create_workspace_file(const std::string& workspace) const {
   // Create file
-  std::string filename = workspace + "/" + TILEDB_WORKSPACE_FILENAME;
+  std::string filename = fs_->append_paths(workspace, TILEDB_WORKSPACE_FILENAME);
   if(create_file(fs_, filename,  O_WRONLY | O_CREAT | O_SYNC, S_IRWXU) == TILEDB_UT_ERR) {
     std::string errmsg = std::string("Failed to create workspace file; ");
     PRINT_ERROR(errmsg);

--- a/core/src/storage_manager/storage_manager.cc
+++ b/core/src/storage_manager/storage_manager.cc
@@ -410,7 +410,7 @@ int StorageManager::array_load_book_keeping(
   for(int i=0; i<fragment_num; ++i) {
     // For easy reference
     int dense = 
-        !is_file(fs_, fragment_names[i] + "/" + TILEDB_COORDS + TILEDB_FILE_SUFFIX);
+        !fs_->is_file(fs_->append_paths(fragment_names[i], std::string(TILEDB_COORDS) + TILEDB_FILE_SUFFIX));
 
     // Create new book-keeping structure for the fragment
     BookKeeping* f_book_keeping = 
@@ -485,7 +485,7 @@ int StorageManager::array_load_schema(
 
   //Old TileDB version - create consolidate file
   if(!(array_schema->version_tag_exists())) {
-    std::string filename = real_array_dir + "/" + TILEDB_SM_CONSOLIDATION_FILELOCK_NAME;
+    std::string filename = fs_->append_paths(real_array_dir, TILEDB_SM_CONSOLIDATION_FILELOCK_NAME);
     if (create_file(fs_, filename,  O_WRONLY | O_CREAT | O_SYNC, S_IRWXU) == TILEDB_UT_ERR) {
       std::string errmsg = "Cannot create consolidation file for old tiledb support";
       tiledb_sm_errmsg = TILEDB_SM_ERRMSG + errmsg;
@@ -1544,7 +1544,7 @@ int StorageManager::consolidation_filelock_create(
     const std::string& dir) const {
   
   // Create file
-  std::string filename = dir + "/" + TILEDB_SM_CONSOLIDATION_FILELOCK_NAME;
+  std::string filename = fs_->append_paths(dir, TILEDB_SM_CONSOLIDATION_FILELOCK_NAME);
   if (create_file(fs_, filename, O_WRONLY | O_CREAT | O_SYNC, S_IRWXU) == TILEDB_UT_ERR) {
     std::string errmsg = std::string("Cannot create consolidation filelock");
     PRINT_ERROR(errmsg);
@@ -1584,9 +1584,7 @@ int StorageManager::consolidation_filelock_lock(
 
   // Prepare the filelock name
   std::string array_name_real = real_dir(fs_, array_name);
-  std::string filename = 
-      array_name_real + "/" + 
-      TILEDB_SM_CONSOLIDATION_FILELOCK_NAME;
+  std::string filename = fs_->append_paths(array_name_real, TILEDB_SM_CONSOLIDATION_FILELOCK_NAME);
 
   // Create consolidation lock file if necessary
   if (!fs_->is_file(filename)) {

--- a/core/src/storage_manager/storage_manager_config.cc
+++ b/core/src/storage_manager/storage_manager_config.cc
@@ -92,8 +92,10 @@ int StorageManagerConfig::init(
     const bool enable_shared_posixfs_optimizations) {
   // Initialize home
   if (home !=  NULL && strstr(home, "://")) {
-     if (fs_ != NULL)
-       delete fs_;
+     if (fs_ != NULL) {
+        delete fs_;
+        fs_ = NULL;
+     }
      home_ = std::string(home, strlen(home));
      if (is_azure_blob_storage_path(home_)) {
        try {

--- a/test/src/c_api/test_tiledb_utils.cc
+++ b/test/src/c_api/test_tiledb_utils.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2019-2020 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2019-2021 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,6 +66,11 @@ TEST_CASE_METHOD(TempDir, "Test initialize_workspace", "[initialize_workspace]")
   CHECK(TileDBUtils::initialize_workspace(&tiledb_ctx, workspace_path+".new", true) == -1); // NOT_DIR
   
   CHECK(TileDBUtils::initialize_workspace(&tiledb_ctx, workspace_path+".new") == -1); // NOT_DIR
+
+  // Try paths with trailing slashes
+  CHECK(TileDBUtils::initialize_workspace(&tiledb_ctx, workspace_path+"1/") == 0); // OK
+  CHECK(TileDBUtils::is_dir(workspace_path+"/"));
+  CHECK(TileDBUtils::is_file(workspace_path+"/"+TILEDB_WORKSPACE_FILENAME));
 }
 
 TEST_CASE_METHOD(TempDir, "Test create_workspace", "[create_workspace]") {
@@ -99,6 +104,11 @@ TEST_CASE_METHOD(TempDir, "Test create_workspace", "[create_workspace]") {
   CHECK(TileDBUtils::delete_dir(workspace_path) == TILEDB_OK);
 
   CHECK(TileDBUtils::create_workspace(workspace_path) == TILEDB_OK);
+
+  // Try paths with trailing slashes
+  CHECK(TileDBUtils::create_workspace(workspace_path+"1/") == TILEDB_OK);
+  CHECK(TileDBUtils::is_dir(workspace_path+"/"));
+  CHECK(TileDBUtils::is_file(workspace_path+"/"+TILEDB_WORKSPACE_FILENAME));
 }
 
 TEST_CASE_METHOD(TempDir, "Test array exists", "[array_exists]") {
@@ -125,6 +135,11 @@ TEST_CASE_METHOD(TempDir, "Test array exists", "[array_exists]") {
   arrays = TileDBUtils::get_array_names(input_ws+"/");
   CHECK(arrays.size()==1);
   CHECK(TileDBUtils::array_exists(input_ws, arrays[0]));
+
+  // Try paths with trailing slashes
+  input_ws = std::string(TILEDB_TEST_DIR)+"/inputs/compatibility_gdb_pre100_ws/";
+  CHECK(TileDBUtils::workspace_exists(input_ws));
+  CHECK(TileDBUtils::array_exists(input_ws, array_name));
 }
 
 TEST_CASE_METHOD(TempDir, "Test get fragment names", "[get_fragment_names]") {

--- a/test/src/c_api/test_tiledb_utils.cc
+++ b/test/src/c_api/test_tiledb_utils.cc
@@ -68,9 +68,10 @@ TEST_CASE_METHOD(TempDir, "Test initialize_workspace", "[initialize_workspace]")
   CHECK(TileDBUtils::initialize_workspace(&tiledb_ctx, workspace_path+".new") == -1); // NOT_DIR
 
   // Try paths with trailing slashes
-  CHECK(TileDBUtils::initialize_workspace(&tiledb_ctx, workspace_path+"1/") == 0); // OK
-  CHECK(TileDBUtils::is_dir(workspace_path+"/"));
-  CHECK(TileDBUtils::is_file(workspace_path+"/"+TILEDB_WORKSPACE_FILENAME));
+  workspace_path = workspace_path+"1/";
+  CHECK(TileDBUtils::initialize_workspace(&tiledb_ctx, workspace_path) == 0); // OK
+  CHECK(TileDBUtils::is_dir(workspace_path));
+  CHECK(TileDBUtils::is_file(workspace_path+TILEDB_WORKSPACE_FILENAME));
 }
 
 TEST_CASE_METHOD(TempDir, "Test create_workspace", "[create_workspace]") {
@@ -106,9 +107,10 @@ TEST_CASE_METHOD(TempDir, "Test create_workspace", "[create_workspace]") {
   CHECK(TileDBUtils::create_workspace(workspace_path) == TILEDB_OK);
 
   // Try paths with trailing slashes
-  CHECK(TileDBUtils::create_workspace(workspace_path+"1/") == TILEDB_OK);
-  CHECK(TileDBUtils::is_dir(workspace_path+"/"));
-  CHECK(TileDBUtils::is_file(workspace_path+"/"+TILEDB_WORKSPACE_FILENAME));
+  workspace_path = workspace_path + "1/";
+  CHECK(TileDBUtils::create_workspace(workspace_path) == TILEDB_OK);
+  CHECK(TileDBUtils::is_dir(workspace_path));
+  CHECK(TileDBUtils::is_file(workspace_path+TILEDB_WORKSPACE_FILENAME));
 }
 
 TEST_CASE_METHOD(TempDir, "Test array exists", "[array_exists]") {
@@ -137,7 +139,7 @@ TEST_CASE_METHOD(TempDir, "Test array exists", "[array_exists]") {
   CHECK(TileDBUtils::array_exists(input_ws, arrays[0]));
 
   // Try paths with trailing slashes
-  input_ws = std::string(TILEDB_TEST_DIR)+"/inputs/compatibility_gdb_pre100_ws/";
+  input_ws = input_ws + "/";
   CHECK(TileDBUtils::workspace_exists(input_ws));
   CHECK(TileDBUtils::array_exists(input_ws, array_name));
 }

--- a/test/src/storage_manager/test_gcs_storage.cc
+++ b/test/src/storage_manager/test_gcs_storage.cc
@@ -123,6 +123,14 @@ TEST_CASE_METHOD(GCSTestFixture, "Test GCS dir", "[dir]") {
   CHECK(gcs_instance->get_dirs("non-existent-dir").size() == 0);
   CHECK(gcs_instance->get_files("non-existent-dir").size() == 0);
 
+  // Try directories with trailing slash
+  std::string test_dir1 = test_dir + "1/";
+  CHECK_RC(gcs_instance->create_dir(test_dir1), TILEDB_FS_OK);
+  CHECK(gcs_instance->is_dir(test_dir1));
+  CHECK(gcs_instance->is_dir(test_dir + "1"));
+  CHECK(!gcs_instance->is_file(test_dir1));
+  CHECK(!gcs_instance->is_file(test_dir1 + "1"));
+
   // TBD: move_path
   std::string new_dir = test_dir+"-new";
   CHECK_THROWS(gcs_instance->move_path(test_dir, new_dir));


### PR DESCRIPTION
Fix the missing certs thrown by curl by trying to find from a list of well known places, logic is borrowed from the [golang compiler source](https://github.com/golang/go/blob/f0e940ebc985661f54d31c8d9ba31a553b87041b/src/crypto/x509/root_linux.go#L7). Another way is to build curl with ca paths -
```
curl-7.57.0$ ./configure --help
`configure' configures curl - to adapt to many kinds of systems.

Usage: ./configure [OPTION]... [VAR=VALUE]...
  --with-ca-bundle=FILE   Path to a file containing CA certificates (example:
                          /etc/ca-bundle.crt)
  --without-ca-bundle     Don't use a default CA bundle
  --with-ca-path=DIRECTORY
                          Path to a directory containing CA certificates
                          stored individually, with their filenames in a hash
                          format. This option can be used with OpenSSL, GnuTLS
                          and PolarSSL backends. Refer to OpenSSL c_rehash for
                          details. (example: /etc/certificates)
  --without-ca-path       Don't use a default CA path
  --with-ca-fallback      Use the built in CA store of the SSL library
  --without-ca-fallback   Don't use the built in CA store of the SSL library
```
I can open an issue if we want to go this route.

For the file path manipulation, use append_paths instead of adding the `slash` directly. This also has a fix from the GenomicsDB side that I will PR after this.

Also, discovered and fixed bug/memory leak with tiledb_ctx_init when storage_manager configuration returned errors. We probably should move to smart pointers, but until then we need to fix this. Otherwise, we see crashes from the JVM/JNI side.

