### PR TITLE
Fix read issues with storage buffer when it contained part of the region to be read

### DIFF
--- a/core/include/storage_manager/storage_fs.h
+++ b/core/include/storage_manager/storage_fs.h
@@ -133,7 +133,6 @@ class StorageFS {
     return slashify(path1) + path2;
   }
 
- protected:
   size_t download_buffer_size_ = 0;
   size_t upload_buffer_size_ = 0;
 };

--- a/core/src/codec/codec.cc
+++ b/core/src/codec/codec.cc
@@ -277,7 +277,7 @@ int Codec::decompress_tile(unsigned char* tile_compressed, size_t tile_compresse
     buffer = pre_compression_filter_->buffer();
   }
   if (do_decompress_tile(tile_compressed, tile_compressed_size, buffer, tile_size)) {
-    return print_errmsg("Could not compress with " + name());
+    return print_errmsg("Could not decompress with " + name());
   }
   if (pre_compression_filter_) {
     if (pre_compression_filter_->decode(tile, tile_size) != 0) {

--- a/test/src/storage_manager/test_storage_buffer.cc
+++ b/test/src/storage_manager/test_storage_buffer.cc
@@ -1,0 +1,112 @@
+/**
+ * @file   test_storage_buffer.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 Omics Data Automation, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * @section DESCRIPTION
+ *
+ * Tests for the StorageBuffer class
+ */
+
+#include "catch.h"
+#include "storage_buffer.h"
+#include "storage_posixfs.h"
+
+TEST_CASE_METHOD(TempDir, "Test Storage Buffer Basic" "[basic]") {
+  std::string filename = get_temp_dir()+"/test-file";
+  std::vector<char> buffer(10);
+  std::generate(buffer.begin(), buffer.end(), std::rand);
+  
+  PosixFS fs;
+  StorageBuffer *storage_buffer = new StorageBuffer(&fs, filename);
+  CHECK_RC(storage_buffer->append_buffer(buffer.data(), 10), TILEDB_BF_ERR); // No upload buffer size set
+  fs.upload_buffer_size_ = 100;
+  CHECK_RC(storage_buffer->append_buffer(buffer.data(), 10), TILEDB_BF_OK);
+  CHECK_RC(storage_buffer->finalize(), TILEDB_BF_OK);
+  delete storage_buffer;
+
+  std::vector<char> check_buffer(10);
+  CHECK(fs.file_size(filename) == 10);
+  CHECK_RC(fs.read_from_file(filename, 0, check_buffer.data(), 10), TILEDB_FS_OK);
+  CHECK(memcmp(buffer.data(), check_buffer.data(), 10) == 0);
+
+  std::vector<char> read_buffer(10);  
+  storage_buffer = new StorageBuffer(&fs, filename+"-non-existent", /*is_read*/true);
+  CHECK_RC(storage_buffer->append_buffer(buffer.data(), 10), TILEDB_BF_ERR); // Cannot write in read_only mode
+  CHECK_RC(storage_buffer->read_buffer(0, read_buffer.data(), 10), TILEDB_BF_ERR); // Non existent file
+  delete storage_buffer;
+
+  storage_buffer = new StorageBuffer(&fs, filename, /*is_read*/true);
+  CHECK_RC(storage_buffer->read_buffer(0, read_buffer.data(), 10), TILEDB_BF_ERR); // No download buffer size
+  fs.download_buffer_size_ = 100;
+  CHECK_RC(storage_buffer->read_buffer(0, read_buffer.data(), 10), TILEDB_BF_OK);
+  CHECK(memcmp(buffer.data(), read_buffer.data(), 10) == 0);
+  CHECK_RC(storage_buffer->read_buffer(0, read_buffer.data(), 100), TILEDB_BF_ERR); // Reading past file
+  delete storage_buffer;
+}
+
+TEST_CASE_METHOD(TempDir, "Test Storage Buffer with buffered reading/writing of large files", "[large-file]") {
+  size_t size = 1024*1024*10; // 10M
+  std::vector<char> buffer(size);
+  std::generate(buffer.begin(), buffer.end(), std::rand);
+
+  PosixFS fs;
+  fs.upload_buffer_size_ = 1024*1024; // 1M chunk
+  fs.download_buffer_size_ = 1024*512; // 0.5M chunk
+
+  std::string filename = get_temp_dir()+"/buffered_file";
+
+  // Buffered write
+  StorageBuffer storage_buffer(&fs, filename, /*is_read*/false);
+  size_t unprocessed = size;
+  do {
+    size_t bytes_to_process = unprocessed<1024?unprocessed:std::rand()%1024;
+    CHECK_RC(storage_buffer.append_buffer(buffer.data()+size-unprocessed, bytes_to_process), TILEDB_BF_OK);
+    unprocessed -= bytes_to_process;
+  } while(unprocessed);
+  CHECK_RC(storage_buffer.finalize(), TILEDB_BF_OK);
+  CHECK(fs.file_size(filename) == size);
+
+  // Check buffered write results with unbuffered read
+  std::vector<char> read_buffer(size);
+  CHECK_RC(fs.read_from_file(filename, 0, read_buffer.data(), size), TILEDB_BF_OK);
+  CHECK_RC(fs.close_file(filename), TILEDB_BF_OK);
+  CHECK(memcmp(buffer.data(), read_buffer.data(), size) == 0);
+
+  // Buffered read
+  StorageBuffer read_storage_buffer(&fs, filename, /*is_read*/true);
+  unprocessed = size;
+  memset(read_buffer.data(), 0, size);
+  unprocessed = size;
+  do {
+    CHECK(size-unprocessed >= 0);
+    size_t bytes_to_process = unprocessed<1024?unprocessed:std::rand()%1024;
+    CHECK_RC(read_storage_buffer.read_buffer(size-unprocessed, read_buffer.data()+size-unprocessed, bytes_to_process), TILEDB_BF_OK);
+    unprocessed -= bytes_to_process;
+  } while(unprocessed);
+  CHECK_RC(read_storage_buffer.finalize(), TILEDB_BF_OK);
+  CHECK(memcmp(buffer.data(), read_buffer.data(), size) == 0);
+}
+


### PR DESCRIPTION
Made it simpler to read regions when the buffered chunk contained only part of the region. We now read a new chunk starting from the new offset even if part was already present in the older chunk. 

Also, added unit tests to test out the `StorageBuffer` class explicitly. The test creates a very large array with random bytes and written/read out in random chunks.