### PR TITLE
Expose real_dir functionality from the storage filesystem layer via TileDBUtils

### DIFF
--- a/core/include/c_api/tiledb_storage.h
+++ b/core/include/c_api/tiledb_storage.h
@@ -94,6 +94,16 @@ bool is_metadata(const TileDB_CTX* tiledb_ctx, const std::string& dir);
  */ 
 bool is_dir(const TileDB_CTX* tiledb_ctx, const std::string& dir);
 
+/**
+ * Returns absolute path for given path only for posix filesystems.
+ * For cloud data stores, this is a noop and returns the given path.
+ *
+ * @param tiledb_ctx TileDB Context
+ * @param dir The directory to be checked.
+ * @return *true* if *dir* is an existing directory, and *false* otherwise.
+ */
+std::string real_dir(const TileDB_CTX* tiledb_ctx, const std::string& dirpath);
+
 /** 
  * Checks if the input is an existing file. 
  *

--- a/core/include/c_api/tiledb_utils.h
+++ b/core/include/c_api/tiledb_utils.h
@@ -58,6 +58,8 @@ std::vector<std::string> get_fragment_names(const std::string& workspace);
 
 bool is_dir(const std::string& dirpath);
 
+std::string real_dir(const std::string& dirpath);
+
 int create_dir(const std::string& dirpath);
 
 int delete_dir(const std::string& dirpath);

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -1848,6 +1848,13 @@ bool is_dir(const TileDB_CTX* tiledb_ctx, const std::string& dir) {
   return invoke_bool_fs_fn(tiledb_ctx, dir, &is_dir);
 }
 
+std::string real_dir(const TileDB_CTX* tiledb_ctx, const std::string& dirpath) {
+   if (sanity_check_fs(tiledb_ctx)) {
+    return real_dir(tiledb_ctx->storage_manager_->get_config()->get_filesystem(), dirpath);
+  }
+  return dirpath;
+}
+
 bool is_file(const TileDB_CTX* tiledb_ctx, const std::string& file) {
   return invoke_bool_fs_fn(tiledb_ctx, file, &is_file);
 }

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -220,6 +220,21 @@ bool is_dir(const std::string& dirpath)
   return check;
 }
 
+std::string real_dir(const std::string& dirpath) {
+  if (is_cloud_path(dirpath)) {
+    return dirpath;
+  } else {
+    TileDB_CTX *tiledb_ctx;
+    if (setup(&tiledb_ctx, parent_dir(dirpath))) {
+      FINALIZE;
+      return dirpath;
+    }
+    std::string real_dirpath = real_dir(tiledb_ctx, dirpath);
+    finalize(tiledb_ctx);
+    return real_dirpath;
+  }
+}
+
 int create_dir(const std::string& dirpath)
 {
   TileDB_CTX *tiledb_ctx;

--- a/test/src/c_api/test_tiledb_utils.cc
+++ b/test/src/c_api/test_tiledb_utils.cc
@@ -72,6 +72,23 @@ TEST_CASE_METHOD(TempDir, "Test initialize_workspace", "[initialize_workspace]")
   CHECK(TileDBUtils::initialize_workspace(&tiledb_ctx, workspace_path) == 0); // OK
   CHECK(TileDBUtils::is_dir(workspace_path));
   CHECK(TileDBUtils::is_file(workspace_path+TILEDB_WORKSPACE_FILENAME));
+
+  // Check out real dir
+  auto real_workspace_path = TileDBUtils::real_dir(workspace_path);
+  if (TileDBUtils::is_cloud_path(workspace_path)) {
+    CHECK(real_workspace_path == workspace_path);
+  } else {
+    CHECK(real_workspace_path.find("//") == std::string::npos);
+    CHECK(real_workspace_path.find("../") == std::string::npos);
+  }
+  auto non_existent_path = workspace_path+"2";
+  auto real_non_existent_path = TileDBUtils::real_dir(non_existent_path);
+  if (TileDBUtils::is_cloud_path(workspace_path)) {
+    CHECK(real_non_existent_path == non_existent_path);
+  } else {
+    CHECK(real_non_existent_path.find("//") == std::string::npos);
+    CHECK(real_non_existent_path.find("../") == std::string::npos);
+  }
 }
 
 TEST_CASE_METHOD(TempDir, "Test create_workspace", "[create_workspace]") {


### PR DESCRIPTION
Need real_dir functionality to use with the proposed new tool vcf2genomicsdb_init for figuring out absolute paths, etc.