### PR TITLE
Move AzureBlob to be based on StorageCloudFS to use locate_ca_certs() and be in sync with GCS and S3 implementations

### DIFF
--- a/core/include/storage_manager/storage_azure_blob.h
+++ b/core/include/storage_manager/storage_azure_blob.h
@@ -48,7 +48,7 @@
 
 using namespace azure::storage_lite;
 
-class AzureBlob : public StorageFS {
+class AzureBlob : public StorageCloudFS {
  public:
   AzureBlob(const std::string& home);
 
@@ -73,11 +73,7 @@ class AzureBlob : public StorageFS {
   int read_from_file(const std::string& filename, off_t offset, void *buffer, size_t length);
   int write_to_file(const std::string& filename, const void *buffer, size_t buffer_size);
   
-  int move_path(const std::string& old_path, const std::string& new_path);
-    
   int sync_path(const std::string& path);
-
-  int close_file(const std::string& filename);
 
   bool locking_support();
 

--- a/core/include/storage_manager/storage_fs.h
+++ b/core/include/storage_manager/storage_fs.h
@@ -180,6 +180,13 @@ class StorageCloudFS : public virtual StorageFS {
 	return location;
       }
     }
+#ifdef DEBUG
+    std::cerr << "CA Certs path not located. Using system defaults" << std::endl;
+#endif
+    return "";
+  }
+#else
+  std::string locate_ca_certs() {
     return "";
   }
 #endif

--- a/core/include/storage_manager/storage_fs.h
+++ b/core/include/storage_manager/storage_fs.h
@@ -38,6 +38,7 @@
 #include "uri.h"
 
 #include <cstring>
+#include <iostream>
 #include <string>
 #include <sys/stat.h>
 #include <system_error>

--- a/core/src/storage_manager/storage_gcs.cc
+++ b/core/src/storage_manager/storage_gcs.cc
@@ -158,20 +158,12 @@ GCS::GCS(const std::string& home) {
     throw std::system_error(EPROTO, std::generic_category(), "GS URI does not seem to have a bucket specified");
   }
 
-#ifdef __linux__
   gcs::ChannelOptions channel_options;
   std::string ca_certs_location = locate_ca_certs();
-  if (ca_certs_location.empty()) {
-#ifdef DEBUG
-    std::cerr << "CA Certs path not located. Using defaults" << std::endl;
-#endif
-  } else {
+  if (!ca_certs_location.empty()) {
     channel_options.set_ssl_root_path(ca_certs_location);
   }
   auto client_options = gcs::ClientOptions::CreateDefaultClientOptions(channel_options);
-#else
-  auto client_options = gcs::ClientOptions::CreateDefaultClientOptions();
-#endif
   if (!client_options) {
     throw std::system_error(EIO, std::generic_category(), "Failed to create default GCS Client Options. "+
                             client_options.status().message());

--- a/core/src/storage_manager/storage_s3.cc
+++ b/core/src/storage_manager/storage_s3.cc
@@ -88,6 +88,10 @@ S3::S3(const std::string& home) {
   }
   std::shared_ptr<Aws::Client::DefaultRetryStrategy> retryStrategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(15, 2);
   client_config.retryStrategy = retryStrategy;
+  std::string ca_certs_location = locate_ca_certs();
+  if (!ca_certs_location.empty()) {
+    client_config.caFile = ca_certs_location.c_str();
+  }
   client_ = std::make_shared<Aws::S3::S3Client>(client_config, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, useVirtualAddressing);
 
   bool bucket_exists = false;


### PR DESCRIPTION
Move AzureBlob to be based on StorageCloudFS to use the locate_ca_certs() functionality and to be more in sync with GCS and S3 implementations