### PR TITLE
Fix issues with CompressedStorageBuffer and cloud storage

### DIFF
--- a/core/include/storage_manager/storage_buffer.h
+++ b/core/include/storage_manager/storage_buffer.h
@@ -175,7 +175,6 @@ class CompressedStorageBuffer : public StorageBuffer {
   const int compression_level_;
   void *compress_buffer_ = NULL;
   size_t compress_buffer_size_ = 0;
-  std::shared_ptr<StorageBuffer> compressed_write_buffer_ = 0;
 
   std::shared_ptr<StorageBuffer> compressed_write_buffer_ = 0;
   size_t compressed_write_buffer_size_ = 0;

--- a/core/include/storage_manager/storage_buffer.h
+++ b/core/include/storage_manager/storage_buffer.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2020-2021 Omics Data Automation Inc.
+ * @copyright Copyright (c) 2020-2022 Omics Data Automation Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,9 +33,10 @@
 #pragma once
 
 #include "storage_fs.h"
-
+#include "storage_posixfs.h"
 #include "tiledb_constants.h"
 
+#include <memory>
 #include <zlib.h>
 
 /* ********************************* */
@@ -64,7 +65,7 @@ class StorageBuffer {
    * Constructor that accepts StorageFS and the filename minimally. StorageBuffer is a no-op
    * if the upload/download limits are not set in StorageFS.
    */
-  StorageBuffer(StorageFS *fs, const std::string& filename, const bool is_read=false);
+  StorageBuffer(StorageFS *fs, const std::string& filename, size_t chunk_size, const bool is_read=false);
 
   virtual ~StorageBuffer() {
     free_buffer();
@@ -99,9 +100,21 @@ class StorageBuffer {
   int append_buffer(const void *bytes, size_t size);
 
   /**
+   * Persist bytes in the buffer to the FileSystem. It is the responsibilty of the client to
+   * check upload file size thresholds for Cloud Storage as only the last block to be uploaded 
+   * can be lower than the threshold. See
+   *     https://cloud.google.com/storage/docs/performing-resumable-uploads#chunked-uploads
+   *     https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html
+   * Currently used internally only with CompressedStorageBuffer.
+   */
+  inline int flush() {
+    return read_only_?TILEDB_FS_OK:write_buffer();
+  }
+
+  /**
    * Finalize flushes existing buffers and releases any allocated memory.
    */
-  int finalize();
+  virtual int finalize();
   
  protected:
   void *buffer_ = NULL;
@@ -136,9 +149,9 @@ class StorageBuffer {
 
 class CompressedStorageBuffer : public StorageBuffer {
  public:
-  CompressedStorageBuffer(StorageFS *fs, const std::string& filename, const bool is_read=false,
+  CompressedStorageBuffer(StorageFS *fs, const std::string& filename, size_t chunk_size, const bool is_read=false,
                           const int compression_type=TILEDB_NO_COMPRESSION, const int compression_level=0)
-      : StorageBuffer(fs, filename, is_read),
+      : StorageBuffer(fs, filename, chunk_size, is_read),
         compression_type_(compression_type), compression_level_(compression_level) {
   }
 
@@ -148,6 +161,7 @@ class CompressedStorageBuffer : public StorageBuffer {
 
   int read_buffer(void *bytes, size_t size);
   int write_buffer();
+  int finalize();
 
   void free_buffer() {
     if (compress_buffer_) free(compress_buffer_);
@@ -161,6 +175,10 @@ class CompressedStorageBuffer : public StorageBuffer {
   const int compression_level_;
   void *compress_buffer_ = NULL;
   size_t compress_buffer_size_ = 0;
+  std::shared_ptr<StorageBuffer> compressed_write_buffer_ = 0;
+
+  std::shared_ptr<StorageBuffer> compressed_write_buffer_ = 0;
+  size_t compressed_write_buffer_size_ = 0;
 
   int initialize_gzip_stream(z_stream *strm);
   int gzip_read_buffer();

--- a/core/src/fragment/book_keeping.cc
+++ b/core/src/fragment/book_keeping.cc
@@ -6,7 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2021 Omics Data Automation Inc.
+ * @copyright Copyright (c) 2021-2022 Omics Data Automation Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -257,11 +257,8 @@ int BookKeeping::finalize(StorageFS *fs) {
   if(!is_dir(fs, fragment_name_))
     return TILEDB_BK_OK;
 
-  // Setup upload size
-  fs->set_upload_buffer_size(upload_uncompressed_size_);
-
   // Create StorageBuffer to serialize book_keeping content
-  buffer_ = new CompressedStorageBuffer(fs, filename_, /*is_read*/false,
+  buffer_ = new CompressedStorageBuffer(fs, filename_, upload_uncompressed_size_, /*is_read*/false,
                                         TILEDB_GZIP, TILEDB_COMPRESSION_LEVEL_GZIP);
 
   // Write non-empty domain
@@ -371,11 +368,8 @@ int BookKeeping::init(const void* non_empty_domain) {
  * last_tile_cell_num(int64_t)
  */
 int BookKeeping::load(StorageFS *fs) {
-  // Setup download size
-  fs->set_download_buffer_size(download_compressed_size_);
-
   // Create StorageBuffer to deserialize book_keeping content
-  buffer_ = new CompressedStorageBuffer(fs, filename_, /*is_read*/ true,
+  buffer_ = new CompressedStorageBuffer(fs, filename_, download_compressed_size_, /*is_read*/ true,
                                         TILEDB_GZIP, TILEDB_COMPRESSION_LEVEL_GZIP);
   
   // Load non-empty domain

--- a/core/src/fragment/read_state.cc
+++ b/core/src/fragment/read_state.cc
@@ -6,7 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2018-2021 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2022 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -1224,12 +1224,12 @@ int ReadState::read_segment(int attribute_num, bool is_var, off_t offset, void *
     if (is_var) {
       assert((attribute_num < attribute_num_) && "Coords attribute cannot be variable");
       if (file_var_buffer_[attribute_num] == NULL) {
-        file_var_buffer_[attribute_num]= new StorageBuffer(fs, filename, true);
+        file_var_buffer_[attribute_num]= new StorageBuffer(fs, filename, fs->get_download_buffer_size(), true);
       }
       file_buffer = file_var_buffer_[attribute_num];
     } else {
       if (file_buffer_[attribute_num] == NULL) {
-        file_buffer_[attribute_num] = new StorageBuffer(fs, filename, true);
+        file_buffer_[attribute_num] = new StorageBuffer(fs, filename, fs->get_download_buffer_size(), true);
       }
       file_buffer = file_buffer_[attribute_num];
     }

--- a/core/src/fragment/write_state.cc
+++ b/core/src/fragment/write_state.cc
@@ -6,7 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
- * @copyright Copyright (c) 2018-2021 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2018-2022 Omics Data Automation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -501,12 +501,12 @@ int WriteState::write_segment(int attribute_id, bool is_var, const void *segment
     if (is_var) {
       assert((attribute_id < attribute_num_) && "Coords attribute cannot be variable");
       if (file_var_buffer_[attribute_id] == NULL) {
-        file_var_buffer_[attribute_id]= new StorageBuffer(fs_, filename);
+        file_var_buffer_[attribute_id]= new StorageBuffer(fs_, filename, fs_->get_upload_buffer_size());
       }
       file_buffer = file_var_buffer_[attribute_id];
     } else {
       if (file_buffer_[attribute_id] == NULL) {
-        file_buffer_[attribute_id] = new StorageBuffer(fs_, filename);
+        file_buffer_[attribute_id] = new StorageBuffer(fs_, filename, fs_->get_upload_buffer_size());
       }
       file_buffer = file_buffer_[attribute_id];
     }

--- a/core/src/storage_manager/storage_buffer.cc
+++ b/core/src/storage_manager/storage_buffer.cc
@@ -403,7 +403,6 @@ int CompressedStorageBuffer::gzip_write_buffer() {
     return TILEDB_BF_ERR;
   }
 
-<<<<<<< HEAD
   // Write directly if and only if the bytes to be written out is greater than the upload_file_size
   if (!fs_->get_upload_buffer_size() || (!compressed_write_buffer_size_ && processed >= fs_->get_upload_buffer_size())) {
     // Write directly
@@ -426,14 +425,6 @@ int CompressedStorageBuffer::gzip_write_buffer() {
       compressed_write_buffer_->flush();
       compressed_write_buffer_size_ = 0;
     }
-=======
-  if (!compressed_write_buffer_) {
-    compressed_write_buffer_ = std::make_shared<StorageBuffer>(fs_, filename_);
-  }
-  if (compressed_write_buffer_->append_buffer(compress_buffer_, processed)) {
-    BUFFER_PATH_ERROR("Cannot write buffer after compression", filename_);
-    return TILEDB_BF_ERR;
->>>>>>> 4921866... Fix for storage buffer with compression and cloud with restrictions where only the last chunk uploaded can be below a threshold
   }
 
   return TILEDB_BF_OK;
@@ -443,17 +434,10 @@ int CompressedStorageBuffer::finalize() {
   int rc = TILEDB_BF_OK;
   if (!read_only_) {
     // Compress and write out any remaining bytes
-<<<<<<< HEAD
     rc = write_buffer();
     if (compressed_write_buffer_) {
       rc = rc || compressed_write_buffer_->finalize();
     }
-=======
-    if (buffer_size_) {
-      rc = write_buffer();
-    }
-    rc = rc || compressed_write_buffer_->finalize();
->>>>>>> 4921866... Fix for storage buffer with compression and cloud with restrictions where only the last chunk uploaded can be below a threshold
     if (rc) {
       BUFFER_PATH_ERROR("Could not finalize buffer after compression", filename_);
     }

--- a/core/src/storage_manager/storage_buffer.cc
+++ b/core/src/storage_manager/storage_buffer.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2020-2021 Omics Data Automation Inc.
+ * @copyright Copyright (c) 2020-2022 Omics Data Automation Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,7 +46,7 @@
 // Using a typical page size for chunks
 #define CHUNK 4096
 
-StorageBuffer::StorageBuffer(StorageFS *fs, const std::string& filename, const bool is_read) :
+StorageBuffer::StorageBuffer(StorageFS *fs, const std::string& filename, size_t chunk_size, const bool is_read) :
     fs_(fs), filename_(filename), read_only_(is_read) {
   if (read_only_) {
     if (fs_->file_size(filename) == TILEDB_FS_ERR) {
@@ -55,15 +55,10 @@ StorageBuffer::StorageBuffer(StorageFS *fs, const std::string& filename, const b
     } else {
       filesize_ = (size_t)fs_->file_size(filename);
     }
-    if (!(chunk_size_ = fs->get_download_buffer_size())) {
-      BUFFER_PATH_ERROR("Cannot perform buffered reads as there is no download buffer size set", filename_);
-      is_error_ = true;
-    }
-  } else {
-    if (!(chunk_size_ = fs->get_upload_buffer_size())) {
-      BUFFER_PATH_ERROR("Cannot perform buffered writes as there is no upload buffer size set", filename_);
-      is_error_ = true;
-    }
+  }
+  if (!(chunk_size_ = chunk_size)) {
+    BUFFER_PATH_ERROR("Cannot perform buffered reads or writes as there is no buffer chunk size set", filename_);
+    is_error_ = true;
   }
 }
 
@@ -169,6 +164,9 @@ int StorageBuffer::append_buffer(const void *bytes, size_t size) {
 }
 
 int StorageBuffer::write_buffer() {
+  if (is_error_) {
+    return TILEDB_BF_ERR;
+  }
   if (fs_->write_to_file(filename_, buffer_, buffer_size_)) {
     BUFFER_PATH_ERROR("Cannot write bytes", filename_);
     return TILEDB_BF_ERR;
@@ -223,6 +221,9 @@ int CompressedStorageBuffer::read_buffer(void *bytes, size_t size) {
 }
 
 int CompressedStorageBuffer::write_buffer() {
+  if (is_error_) {
+    return TILEDB_BF_ERR;
+  }
   if (buffer_size_ > 0) {
     switch (compression_type_) {
       case TILEDB_GZIP:
@@ -402,10 +403,60 @@ int CompressedStorageBuffer::gzip_write_buffer() {
     return TILEDB_BF_ERR;
   }
 
-  if (fs_->write_to_file(filename_, compress_buffer_, processed)) {
-    BUFFER_PATH_ERROR("Cannot write bytes", filename_);
+<<<<<<< HEAD
+  // Write directly if and only if the bytes to be written out is greater than the upload_file_size
+  if (!fs_->get_upload_buffer_size() || (!compressed_write_buffer_size_ && processed >= fs_->get_upload_buffer_size())) {
+    // Write directly
+    if (fs_->write_to_file(filename_, compress_buffer_, processed)) {
+      BUFFER_PATH_ERROR("Cannot write bytes", filename_);
+      return TILEDB_BF_ERR;
+    }
+  } else {
+    // Use another buffer to hold the compressed bytes until the minimum upload_file_size is satisfied
+    if (!compressed_write_buffer_) {
+      assert(compressed_write_buffer_size_ == 0);
+      compressed_write_buffer_ = std::make_shared<StorageBuffer>(fs_, filename_, fs_->get_upload_buffer_size());
+    }
+    if (compressed_write_buffer_->append_buffer(compress_buffer_, processed)) {
+      BUFFER_PATH_ERROR("Cannot write buffer after compression", filename_);
+      return TILEDB_BF_ERR;
+    }
+    compressed_write_buffer_size_ += processed;
+    if (compressed_write_buffer_size_ >= fs_->get_upload_buffer_size()) {
+      compressed_write_buffer_->flush();
+      compressed_write_buffer_size_ = 0;
+    }
+=======
+  if (!compressed_write_buffer_) {
+    compressed_write_buffer_ = std::make_shared<StorageBuffer>(fs_, filename_);
+  }
+  if (compressed_write_buffer_->append_buffer(compress_buffer_, processed)) {
+    BUFFER_PATH_ERROR("Cannot write buffer after compression", filename_);
     return TILEDB_BF_ERR;
+>>>>>>> 4921866... Fix for storage buffer with compression and cloud with restrictions where only the last chunk uploaded can be below a threshold
   }
 
   return TILEDB_BF_OK;
+}
+
+int CompressedStorageBuffer::finalize() {
+  int rc = TILEDB_BF_OK;
+  if (!read_only_) {
+    // Compress and write out any remaining bytes
+<<<<<<< HEAD
+    rc = write_buffer();
+    if (compressed_write_buffer_) {
+      rc = rc || compressed_write_buffer_->finalize();
+    }
+=======
+    if (buffer_size_) {
+      rc = write_buffer();
+    }
+    rc = rc || compressed_write_buffer_->finalize();
+>>>>>>> 4921866... Fix for storage buffer with compression and cloud with restrictions where only the last chunk uploaded can be below a threshold
+    if (rc) {
+      BUFFER_PATH_ERROR("Could not finalize buffer after compression", filename_);
+    }
+  }
+  return StorageBuffer::finalize() || rc;
 }

--- a/core/src/storage_manager/storage_gcs.cc
+++ b/core/src/storage_manager/storage_gcs.cc
@@ -360,8 +360,9 @@ int GCS::write_to_file(const std::string& filename, const void *buffer, size_t b
       update_info.last_uploaded_size_ = buffer_size;
       write_map_.insert({filepath, std::move(update_info)});
     } else {
-      if (search->second.last_uploaded_size_ < 5*1024*1024) {
-        GCS_ERROR("Only the last of the uploadable parts can be less than 5MB, try increasing TILEDB_UPLOAD_BUFFER_SIZE to at least 5MB", filepath);
+      // https://cloud.google.com/storage/docs/performing-resumable-uploads#chunked-upload
+      if (search->second.last_uploaded_size_ < 256*1024) {
+        GCS_ERROR("Only the last of the uploadable parts can be less than 256KB", filepath);
         return TILEDB_FS_ERR;
       }
       part_number = ++search->second.part_number_;

--- a/core/src/storage_manager/storage_s3.cc
+++ b/core/src/storage_manager/storage_s3.cc
@@ -404,9 +404,11 @@ int S3::write_to_file(const std::string& filename, const void *buffer, size_t bu
     part_number = found->second.part_number_;
     completed_parts = found->second.completed_parts_;
     // Verify that the previous uploaded part was at least 5M - see https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html
+    // S3 throws error only when committing, so it is better to check in write_to_file and abort here. Note that cleanup occurs
+    // in commit_file that is called from the destructor if there was an issue.
     auto last_uploaded_size = found->second.last_uploaded_size_;
     if (found->second.abort_upload_ || (last_uploaded_size != 0 && last_uploaded_size < 5*1024*1024)) {
-      S3_ERROR("Only the last of the uploadable parts can be less than 5Mb, try increasing TILEDB_UPLOAD_BUFFER_SIZE to at least 5Mb", filepath);
+      S3_ERROR("Only the last of the uploadable parts can be less than 5MB", filepath);
       found->second.abort_upload_ = true;
       return TILEDB_FS_ERR;
     } else {

--- a/test/src/storage_manager/test_storage_buffer.cc
+++ b/test/src/storage_manager/test_storage_buffer.cc
@@ -175,19 +175,12 @@ class TestBufferedWrite : public TempDir {
 };
 
 TEST_CASE_METHOD(TestBufferedWrite, "Test Storage Buffer with buffered reading/writing of large files", "[large-file]") {
-<<<<<<< HEAD
   size_t size = 1024*1024*20 + 1024; // 20M + 1024
-=======
-  size_t size = 1024*1024*10 + 1024; // 10M + 1024
->>>>>>> 4921866... Fix for storage buffer with compression and cloud with restrictions where only the last chunk uploaded can be below a threshold
   std::vector<char> buffer(size);
   std::generate(buffer.begin(), buffer.end(), std::rand);
 
   std::shared_ptr<StorageFS> fs;
-<<<<<<< HEAD
   bool is_posix = false;
-=======
->>>>>>> 4921866... Fix for storage buffer with compression and cloud with restrictions where only the last chunk uploaded can be below a threshold
 
   // Buffered write
   std::string filename = get_temp_dir()+"/buffered_file";
@@ -199,7 +192,6 @@ TEST_CASE_METHOD(TestBufferedWrite, "Test Storage Buffer with buffered reading/w
     fs = std::make_shared<S3>(filename);
   } else {
     fs = std::make_shared<PosixFS>();
-<<<<<<< HEAD
     is_posix = true;
   }
 
@@ -210,16 +202,6 @@ TEST_CASE_METHOD(TestBufferedWrite, "Test Storage Buffer with buffered reading/w
   StorageBuffer storage_buffer(fs.get(), filename, write_chunk_size, /*is_read*/false);
   write(filename, &storage_buffer, buffer.data(), size);
   CHECK((size_t)fs->file_size(filename) == size);
-=======
-    fs->upload_buffer_size_ = 1024*1024; // 1M chunk
-    fs->download_buffer_size_ = 1024*512; // 0.5M chunk
-  }
-
-  // Buffered write
-  StorageBuffer storage_buffer(fs.get(), filename, /*is_read*/false);
-  write(filename, &storage_buffer, buffer.data(), size);
-  CHECK(fs->file_size(filename) == size);
->>>>>>> 4921866... Fix for storage buffer with compression and cloud with restrictions where only the last chunk uploaded can be below a threshold
 
   // Check buffered write results with unbuffered read
   std::vector<char> read_buffer(size);
@@ -228,40 +210,24 @@ TEST_CASE_METHOD(TestBufferedWrite, "Test Storage Buffer with buffered reading/w
   CHECK(memcmp(buffer.data(), read_buffer.data(), size) == 0);
 
   // Buffered read
-<<<<<<< HEAD
   StorageBuffer read_storage_buffer(fs.get(), filename, read_chunk_size, /*is_read*/true);
-=======
-  StorageBuffer read_storage_buffer(fs.get(), filename, /*is_read*/true);
->>>>>>> 4921866... Fix for storage buffer with compression and cloud with restrictions where only the last chunk uploaded can be below a threshold
   memset(read_buffer.data(), 0, size);
   read(filename, &read_storage_buffer, read_buffer.data(), size);
   CHECK(memcmp(buffer.data(), read_buffer.data(), size) == 0);
 
   // Buffered read with implicit offset
-<<<<<<< HEAD
   CompressedStorageBuffer read_storage_buffer_1(fs.get(), filename, write_chunk_size, /*is_read*/true);
-=======
-  CompressedStorageBuffer read_storage_buffer_1(fs.get(), filename, /*is_read*/true);
->>>>>>> 4921866... Fix for storage buffer with compression and cloud with restrictions where only the last chunk uploaded can be below a threshold
   memset(read_buffer.data(), 0, size);
   read_with_implicit_offset(filename, &read_storage_buffer_1, read_buffer.data(), size);
   CHECK(memcmp(buffer.data(), read_buffer.data(), size) == 0);
 
   // Buffered write with compression
   filename += ".compress";
-<<<<<<< HEAD
   CompressedStorageBuffer storage_buffer_with_compression(fs.get(), filename, write_chunk_size, false, TILEDB_GZIP, TILEDB_COMPRESSION_LEVEL_GZIP);
   write(filename, &storage_buffer_with_compression, buffer.data(), size);
 
   // Buffered read with decompression
   CompressedStorageBuffer read_storage_buffer_with_compression(fs.get(), filename, read_chunk_size, true, TILEDB_GZIP);
-=======
-  CompressedStorageBuffer storage_buffer_with_compression(fs.get(), filename, false, TILEDB_GZIP);
-  write(filename, &storage_buffer_with_compression, buffer.data(), size);
-
-  // Buffered read with decompression
-  CompressedStorageBuffer read_storage_buffer_with_compression(fs.get(), filename, true, TILEDB_GZIP);
->>>>>>> 4921866... Fix for storage buffer with compression and cloud with restrictions where only the last chunk uploaded can be below a threshold
   memset(read_buffer.data(), 0, size);
   read_with_implicit_offset(filename, &read_storage_buffer_with_compression, read_buffer.data(), size);
   CHECK(memcmp(buffer.data(), read_buffer.data(), size) == 0);


### PR DESCRIPTION
Fix issues with CompressedStorageBuffer and cloud storage. The StorageBuffer explicitly requires the buffer chunks to be specified in the construct and the CompressedStorageBuffer now 

1. Write bytes directly for Posix Filesystems (download_buffer_size == 0)
2. Write bytes directly for Cloud Storage if the size is greater than the download_buffer_size
3. Use a buffered write for all other cases and flush(write out) if the buffer size exceeds the download_buffer_size.

This also fixes a bug in fragment.cc, where the `__tiledb_fragment.tdb` was getting written out even with book-keeping failures.
