### PR TITLE
Support <multiarch-tuple> with debian/ubuntu builds

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -67,6 +67,7 @@ jobs:
         if [[ ${{matrix.type}} == "basic-codec" ]]; then
           source $GITHUB_WORKSPACE/.github/scripts/install_supported_codec.sh
         fi
+        echo "CMAKE VERSION=$(cmake --version)"
         cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
                -DENABLE_ZSTD=$ENABLE_ZSTD -DENABLE_BLOSC=$ENABLE_BLOSC -DAWSSDK_URL=$AWSSDK_URL $USE_HDFS
       env:

--- a/cmake/Modules/FindGCSClient.cmake
+++ b/cmake/Modules/FindGCSClient.cmake
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2021 Omics Data Automation, Inc.
+# Copyright (c) 2022 Omics Data Automation, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@ add_custom_target(gcssdk-ep)
 message(CHECK_START "Finding GCS SDK Library")
 
 include(GNUInstallDirs)
+
 if(GCSSDK_ROOT_DIR)
   set(GCSSDK_PREFIX "${GCSSDK_ROOT_DIR}")
 elseif(DEFINED ENV{GCSSDK_ROOT_DIR})
@@ -68,6 +69,7 @@ elseif(NOT GCSSDK_FOUND)
         -DCMAKE_CXX_STANDARD=11
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=${GCSSDK_PREFIX}
+        -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
     )
 
   # gcssdk has abseil as its dependency, so build that first
@@ -81,6 +83,7 @@ elseif(NOT GCSSDK_FOUND)
         -DCMAKE_CXX_STANDARD=11
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=${GCSSDK_PREFIX}
+        -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
         )
 
   ExternalProject_Add(crc32-build
@@ -95,6 +98,7 @@ elseif(NOT GCSSDK_FOUND)
         -DCMAKE_CXX_STANDARD=11
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=${GCSSDK_PREFIX}
+        -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
         )
 
   ExternalProject_Add(gcssdk-build
@@ -110,6 +114,7 @@ elseif(NOT GCSSDK_FOUND)
         -DCMAKE_CXX_VISIBILITY_PRESET=hidden
         -DCMAKE_INSTALL_PREFIX=${GCSSDK_PREFIX}
         -DCMAKE_PREFIX_PATH=${GCSSDK_PREFIX}
+        -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
         )
 
   add_dependencies(gcssdk-build nlohmann-build)

--- a/cmake/Modules/FindS3Client.cmake
+++ b/cmake/Modules/FindS3Client.cmake
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2021 Omics Data Automation, Inc.
+# Copyright (c) 2022 Omics Data Automation, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@ add_custom_target(awssdk-ep)
 message(CHECK_START "Finding AWS SDK Library")
 
 include(GNUInstallDirs)
+
 if(AWSSDK_ROOT_DIR)
   set(AWSSDK_PREFIX "${AWSSDK_ROOT_DIR}")
 elseif(DEFINED ENV{AWSSDK_ROOT_DIR})
@@ -60,21 +61,58 @@ elseif(NOT AWSSDK_FOUND)
   message(STATUS "Adding AWS SDK as an external project")
   include(ExternalProject)
 
+  ExternalProject_Add(aws-c-common-build
+    URL "https://github.com/awslabs/aws-c-common/archive/v0.6.9.tar.gz"
+    CMAKE_ARGS
+    -DBUILD_SHARED_LIBS=OFF
+    -DENABLE_TESTING=OFF
+    -DENABLE_UNITY_BUILD=ON
+    -DCMAKE_INSTALL_PREFIX=${AWSSDK_PREFIX}
+    -DCMAKE_PREFIX_PATH=${AWSSDK_PREFIX}
+    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR})
+
+  ExternalProject_Add(aws-checksums-build
+    URL "https://github.com/awslabs/aws-checksums/archive/v0.1.12.tar.gz"
+    CMAKE_ARGS 
+    -DBUILD_SHARED_LIBS=OFF
+    -DENABLE_TESTING=OFF
+    -DENABLE_UNITY_BUILD=ON
+    -DCMAKE_INSTALL_PREFIX=${AWSSDK_PREFIX}
+    -DCMAKE_PREFIX_PATH=${AWSSDK_PREFIX}
+    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
+    DEPENDS aws-c-common-build)
+  
+  ExternalProject_Add(aws-c-event-stream-build
+    URL "https://github.com/awslabs/aws-c-event-stream/archive/v0.1.5.tar.gz"
+    CMAKE_ARGS ${AWSSDK_COMMON_CMAKE_ARGS}
+    -DBUILD_SHARED_LIBS=OFF
+    -DENABLE_TESTING=OFF
+    -DENABLE_UNITY_BUILD=ON
+    -DCMAKE_INSTALL_PREFIX=${AWSSDK_PREFIX}
+    -DCMAKE_PREFIX_PATH=${AWSSDK_PREFIX}
+    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
+    DEPENDS aws-checksums-build)
+
   ExternalProject_Add(awssdk-build
     PREFIX ${AWSSDK_PREFIX}
     URL ${AWSSDK_URL}
     PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/cmake/patches/awssdk-build.patch
     CMAKE_ARGS
-        -DBUILD_SHARED_LIBS=OFF
-        -DENABLE_TESTING=OFF
-        -DENABLE_UNITY_BUILD=ON
-        -DCUSTOM_MEMORY_MANAGEMENT=OFF
-        -DBUILD_ONLY=config\\$<SEMICOLON>s3\\$<SEMICOLON>transfer\\$<SEMICOLON>identity-management\\$<SEMICOLON>sts
-        -DMINIMIZE_SIZE=ON
-        -DCMAKE_BUILD_TYPE=Release
-        -DCMAKE_INSTALL_PREFIX=${AWSSDK_PREFIX}
-        -DCMAKE_PREFIX_PATH=${AWSSDK_PREFIX}
-        )
+    -DBUILD_SHARED_LIBS=OFF
+    -DENABLE_TESTING=OFF
+    -DENABLE_UNITY_BUILD=ON
+    -DCUSTOM_MEMORY_MANAGEMENT=OFF
+    -DBUILD_DEPS=OFF
+    -DBUILD_ONLY=config\\$<SEMICOLON>s3\\$<SEMICOLON>transfer\\$<SEMICOLON>identity-management\\$<SEMICOLON>sts
+    -DMINIMIZE_SIZE=ON
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX=${AWSSDK_PREFIX}
+    -DCMAKE_PREFIX_PATH=${AWSSDK_PREFIX}
+    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR})
+
+  add_dependencies(awssdk-build aws-c-common-build)
+  add_dependencies(awssdk-build aws-c-event-stream-build)
+  add_dependencies(awssdk-build aws-checksums-build)
   add_dependencies(awssdk-ep awssdk-build)
 
    # AWS C++ SDK related libraries to link statically

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -58,6 +58,9 @@ endif()
 set_target_properties(tiledb_static PROPERTIES OUTPUT_NAME "tiledb")
 set_target_properties(tiledb_shared PROPERTIES OUTPUT_NAME "tiledb")
 
+include(GNUInstallDirs)
+unset(CMAKE_LIBRARY_ARCHITECTURE)
+
 target_link_libraries(tiledb_static muparserx azure-storage-lite ${AWSSDK_LINK_LIBRARIES} ${GCSSDK_LINK_LIBRARIES})
 target_link_libraries(tiledb_shared ${TILEDB_LIB_DEPENDENCIES})
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -58,9 +58,6 @@ endif()
 set_target_properties(tiledb_static PROPERTIES OUTPUT_NAME "tiledb")
 set_target_properties(tiledb_shared PROPERTIES OUTPUT_NAME "tiledb")
 
-include(GNUInstallDirs)
-unset(CMAKE_LIBRARY_ARCHITECTURE)
-
 target_link_libraries(tiledb_static muparserx azure-storage-lite ${AWSSDK_LINK_LIBRARIES} ${GCSSDK_LINK_LIBRARIES})
 target_link_libraries(tiledb_shared ${TILEDB_LIB_DEPENDENCIES})
 


### PR DESCRIPTION
GitHub Actions has enabled [multi arch support ](https://wiki.debian.org/Multiarch/Tuples) for Ubuntu causing TileDB builds to fail. This PR allows for \<multiarch-tuple\> on debian/ubuntu if enabled by passing CMAKE_INSTALL_LIBDIR to ExternalProjects. Also, awssdk was not passing the CMAKE_INSTALL_LIBDIR to its C dependencies, so installing all the awssdk C dependencies explicitly as ExternalProjects.