### PR TITLE
Move to latest version of azure-storage-cpplite

### DIFF
--- a/core/EnvironmentVariables.md
+++ b/core/EnvironmentVariables.md
@@ -16,3 +16,5 @@ The use of these Environment Variables will alter the behavior of TileDB. These 
 * TILEDB_USE_GCS_HDFS_CONNECTOR
      gs:// URLs, by default use the GCS SDK Client. But, this behavior can be overridden to use Google HDFS Connector if necesary.
 
+* TILEDB_MAX_STREAM_SIZE
+     For azure blob storage, use download_blob_to_stream to read lengths < TILEDB_MAX_STREAM_SIZE. If this is not set, the default is 32 bytes defined in core/include/storage_manager/storage_azure_blob.h.

--- a/core/include/c_api/tiledb_utils.h
+++ b/core/include/c_api/tiledb_utils.h
@@ -72,6 +72,8 @@ std::vector<std::string> get_files(const std::string& dirpath);
 
 ssize_t file_size(const std::string& filepath);
 
+void print_md5_hash(unsigned char* buffer, size_t length);
+
 /**
  * buffer is malloc'ed and has to be freed by calling function
  */

--- a/core/include/storage_manager/storage_azure_blob.h
+++ b/core/include/storage_manager/storage_azure_blob.h
@@ -131,6 +131,8 @@ class AzureBlob : public StorageCloudFS {
     }
   };
 
+  size_t max_stream_size = 32;
+
   std::string get_path(const std::string& path);
 
   std::vector<std::string> generate_block_ids(const std::string& path, int num_blocks) {

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -352,10 +352,12 @@ int read_entire_file(const std::string& filename, void **buffer, size_t *length)
   int rc = read_file(tiledb_ctx, filename, 0, *buffer, size);
   if (!rc) {
     *length = size;
+#ifdef DEBUG
     // Calculate md5 hash for buffer
     std::cerr << "MD5 for buffer after reading : ";
     print_md5_hash((unsigned char *)(*buffer), size);
     std::cerr << std::endl;
+#endif
     rc = close_file(tiledb_ctx, filename);
   } else {
     memset(*buffer, 0, size+1);

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -331,7 +331,6 @@ void print_md5_hash(unsigned char* buffer, size_t length) {
   MD5(buffer, length, md);
   for(auto i=0; i <MD5_DIGEST_LENGTH; i++) {
     fprintf(stderr, "%02x",md[i]);
-    //    std::cerr  << md[i];
   }
 }
 

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -344,11 +344,15 @@ int AzureBlob::delete_file(const std::string& filename) {
 ssize_t AzureBlob::file_size(const std::string& filename) {
   auto blob_property = blob_client_wrapper_->get_blob_property(container_name_, get_path(filename));
   if (blob_property.valid()) {
+    if (filename.find_last_of(".json") != std::string::npos) {
+      std::cerr << "Blob " << filename << " md5=" << blob_property.content_md5 << " size=" << blob_property.size<< std::endl;
+    }
     return blob_property.size;
   } else {
+    std::cerr << "No blob properties found for file=" << filename << std::endl;
     return TILEDB_FS_ERR;
   }
-  return 0;
+  return TILEDB_FS_OK;
 }
 
 int AzureBlob::read_from_file(const std::string& filename, off_t offset, void *buffer, size_t length) {

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -229,7 +229,7 @@ AzureBlob::AzureBlob(const std::string& home) {
   download_buffer_size_ = constants::default_block_size; // 8M
   upload_buffer_size_ = constants::default_block_size; // 8M
 
-  auto max_stream_size_var = getenv("MAX_STREAM_SIZE");
+  auto max_stream_size_var = getenv("TILEDB_MAX_STREAM_SIZE");
   if (max_stream_size_var) {
     max_stream_size = std::stoll(max_stream_size_var);
   }
@@ -344,9 +344,11 @@ int AzureBlob::delete_file(const std::string& filename) {
 ssize_t AzureBlob::file_size(const std::string& filename) {
   auto blob_property = blob_client_wrapper_->get_blob_property(container_name_, get_path(filename));
   if (blob_property.valid()) {
+#ifdef DEBUG
     if (filename.find_last_of(".json") != std::string::npos) {
       std::cerr << "Blob " << filename << " md5=" << blob_property.content_md5 << " size=" << blob_property.size<< std::endl;
     }
+#endif
     return blob_property.size;
   } else {
     std::cerr << "No blob properties found for file=" << filename << std::endl;

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -228,6 +228,11 @@ AzureBlob::AzureBlob(const std::string& home) {
   // Set default buffer sizes, overridden with env vars TILEDB_DOWNLOAD_BUFFER_SIZE and TILEDB_UPLOAD_BUFFER_SIZE
   download_buffer_size_ = constants::default_block_size; // 8M
   upload_buffer_size_ = constants::default_block_size; // 8M
+
+  auto max_stream_size_var = getenv("MAX_STREAM_SIZE");
+  if (max_stream_size_var) {
+    max_stream_size = std::stoll(max_stream_size_var);
+  }
 }
 
 std::string AzureBlob::current_dir() {
@@ -346,8 +351,6 @@ ssize_t AzureBlob::file_size(const std::string& filename) {
   return 0;
 }
 
-#define GRAIN_SIZE (4*1024*1024)
-
 int AzureBlob::read_from_file(const std::string& filename, off_t offset, void *buffer, size_t length) {
   if (length == 0) {
     return TILEDB_FS_OK; // Nothing to read
@@ -356,7 +359,7 @@ int AzureBlob::read_from_file(const std::string& filename, off_t offset, void *b
   auto bclient = reinterpret_cast<blob_client *>(blob_client_.get());
   storage_outcome<void> read_result;
   // Heuristic: if the file can be contained in a block use download_blob_to_stream(), otherwise use the parallel download_blob_to_buffer()
-  if (length < GRAIN_SIZE) {
+  if (length <= max_stream_size) {
     omemstream os_buf(buffer, length);
     read_result = bclient->download_blob_to_stream(container_name_, path, offset, length, os_buf).get();
   } else {
@@ -370,6 +373,7 @@ int AzureBlob::read_from_file(const std::string& filename, off_t offset, void *b
   }
 }
 
+#define GRAIN_SIZE (4*1024*1024)
 // This method is based on upload_block_blob_from_buffer from the SDK except for the put_block_list stage which happens in commit_path() now
 std::future<storage_outcome<void>> AzureBlob::upload_block_blob(const std::string &blob, uint64_t block_size,
                                                                 int num_blocks, std::vector<std::string> block_ids,

--- a/test/src/c_api/test_tiledb_utils.cc
+++ b/test/src/c_api/test_tiledb_utils.cc
@@ -231,6 +231,7 @@ TEST_CASE_METHOD(TempDir, "Test file operations", "[file_ops]") {
   char buffer[1024];
   memset(buffer, 'H', 1024);
   CHECK(TileDBUtils::write_file(filename, buffer, 1024) == TILEDB_OK);
+  TileDBUtils::print_md5_hash((unsigned char *)buffer, 1024);
 
   void *read_buffer = NULL;
   size_t length;
@@ -241,6 +242,7 @@ TEST_CASE_METHOD(TempDir, "Test file operations", "[file_ops]") {
     char *ptr = (char *)(read_buffer)+i;
     CHECK(*ptr == 'H');
   }
+  TileDBUtils::print_md5_hash((unsigned char *)read_buffer, 1024);
   free(read_buffer);
 
   memset(buffer, 0, 1024);

--- a/test/src/c_api/test_tiledb_utils.cc
+++ b/test/src/c_api/test_tiledb_utils.cc
@@ -252,6 +252,19 @@ TEST_CASE_METHOD(TempDir, "Test file operations", "[file_ops]") {
   CHECK(TileDBUtils::file_size(filename) == 1024); // for existing file
   CHECK(TileDBUtils::file_size("non-existing-file") == -1);
 
+  // Try renaming file and reading contents
+  std::string new_filename = filename+".old";
+  CHECK(TileDBUtils::move_across_filesystems(filename, new_filename) == TILEDB_OK);
+  CHECK(TileDBUtils::file_size(new_filename) == 1024);
+  CHECK(TileDBUtils::read_entire_file(new_filename, &read_buffer, &length) == TILEDB_OK);
+  CHECK(read_buffer);
+  CHECK(length == 1024);
+  for (auto i=0; i<1024; i++) {
+    char *ptr = (char *)(read_buffer)+i;
+    CHECK(*ptr == 'H');
+  }
+  free(read_buffer);
+
   // TODO: Should investigate why the hdfs java io exceptions are not being propagated properly from catch2.
   if (TileDBUtils::is_cloud_path(filename)) {
     return;

--- a/test/src/storage_manager/test_azure_blob_storage.cc
+++ b/test/src/storage_manager/test_azure_blob_storage.cc
@@ -36,6 +36,7 @@
 #include "utils.h"
 
 #include <fcntl.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -208,6 +209,11 @@ TEST_CASE_METHOD(AzureBlobTestFixture, "Test AzureBlob read/write file", "[read-
   CHECK(azure_blob->file_size(test_dir+"/foo") == 11);
   CHECK_RC(azure_blob->read_from_file(test_dir+"/foo", 0, buffer, 11), TILEDB_FS_OK);
   CHECK(((char *)buffer)[10] == 'e');
+
+  REQUIRE(setenv("TILEDB_MAX_STREAM_SIZE", "4", 0) == 0);
+  CHECK_RC(azure_blob->read_from_file(test_dir+"/foo", 0, buffer, 11), TILEDB_FS_OK);
+  CHECK(((char *)buffer)[10] == 'e');
+  REQUIRE(unsetenv("TILEDB_MAX_STREAM_SIZE") == 0);
 
   CHECK_RC(azure_blob->close_file(test_dir+"/foo"), TILEDB_FS_OK);
   CHECK_RC(azure_blob->delete_file(test_dir+"/foo"), TILEDB_FS_OK);


### PR DESCRIPTION
Moved to the latest version of azure-storage-cpplite to help alleviate some network related issues with azure blob storage. Also, added a little bit of debugging and some minor refactoring to pinpoint the network issues if they arise.