### PR TITLE
Move the 'MD5 for buffer after reading...' statements from ifdef DEBUG to if 0

### DIFF
--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -352,7 +352,7 @@ int read_entire_file(const std::string& filename, void **buffer, size_t *length)
   int rc = read_file(tiledb_ctx, filename, 0, *buffer, size);
   if (!rc) {
     *length = size;
-#ifdef DEBUG
+#ifdef 0
     // Calculate md5 hash for buffer
     std::cerr << "MD5 for buffer after reading : ";
     print_md5_hash((unsigned char *)(*buffer), size);

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -352,7 +352,7 @@ int read_entire_file(const std::string& filename, void **buffer, size_t *length)
   int rc = read_file(tiledb_ctx, filename, 0, *buffer, size);
   if (!rc) {
     *length = size;
-#ifdef 0
+#if 0
     // Calculate md5 hash for buffer
     std::cerr << "MD5 for buffer after reading : ";
     print_md5_hash((unsigned char *)(*buffer), size);


### PR DESCRIPTION
Just annoying to see tests, etc. peppered with this MD5 message, so moving it to 0 for the time being. @mlathara, let me know if you still want to keep this in debug mode?