### PR TITLE
Use HeadBucket instead of ListBuckets from AWS::S3::Model for checking bucket existence

### DIFF
--- a/test/src/storage_manager/test_s3_storage.cc
+++ b/test/src/storage_manager/test_s3_storage.cc
@@ -185,9 +185,7 @@ TEST_CASE_METHOD(S3TestFixture, "Test S3 read/write file", "[read-write]") {
   CHECK_RC(s3_instance->sync_path(test_dir+"/foo"), TILEDB_FS_OK);
   CHECK_RC(s3_instance->close_file(test_dir+"/foo"), TILEDB_FS_OK);
   auto files = s3_instance->get_files(test_dir);
-  for(auto f: files) {
-    std::cerr << "file=" << f << std::endl;
-  }
+  CHECK(files.size() == 1);
   REQUIRE(s3_instance->is_file(test_dir+"/foo"));
   CHECK(s3_instance->file_size(test_dir+"/foo") == 5);
 


### PR DESCRIPTION
This is the solution to @mlathara reporting issues with users not having permissions to perform [ListBuckets](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html) and suggested using [HeadBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html) instead. 