### PR TITLE
Fix g++ warnings

### DIFF
--- a/core/include/expressions/expression.h
+++ b/core/include/expressions/expression.h
@@ -109,9 +109,9 @@ class Expression {
 
   std::vector<int64_t> last_processed_buffer_index_;
 
-  void assign_single_cell_value(const int attribute_id, void** buffers, const uint64_t buffer_index, const int64_t position);
-  void assign_fixed_cell_values(const int attribute_id, void** buffers, const uint64_t buffer_index, const int64_t position);
-  void assign_var_cell_values(const int attribute_id, void** buffers, size_t *buffer_sizes, const uint64_t buffer_index, const int64_t position);
+  void assign_single_cell_value(const int attribute_id, void** buffers, const uint64_t buffer_index, const uint64_t position);
+  void assign_fixed_cell_values(const int attribute_id, void** buffers, const uint64_t buffer_index, const uint64_t position);
+  void assign_var_cell_values(const int attribute_id, void** buffers, size_t *buffer_sizes, const uint64_t buffer_index, const uint64_t position);
 
   inline const int get_cell_val_num(const std::string& attribute_name) const {
     return array_schema_->cell_val_num(array_schema_->attribute_id(attribute_name));

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -52,8 +52,7 @@ static int setup(TileDB_CTX **ptiledb_ctx, const std::string& home,
                  const bool enable_shared_posixfs_optimizations=false)
 {
   int rc;
-  TileDB_Config tiledb_config;
-  memset(&tiledb_config, 0, sizeof(TileDB_Config));
+  TileDB_Config tiledb_config = {};
   tiledb_config.home_ = strdup(home.c_str());
   tiledb_config.enable_shared_posixfs_optimizations_ = enable_shared_posixfs_optimizations;
   rc = tiledb_ctx_init(ptiledb_ctx, &tiledb_config);

--- a/test/include/benchmark/tiledb_benchmark.h
+++ b/test/include/benchmark/tiledb_benchmark.h
@@ -326,8 +326,7 @@ class BenchmarkConfig: public TempDir {
 // TileDB  Benchmark Utils
 void create_workspace(BenchmarkConfig* config) {
   TileDB_CTX* tiledb_ctx;
-  TileDB_Config tiledb_config;
-  memset(&tiledb_config, 0, sizeof(TileDB_Config));
+  TileDB_Config tiledb_config = {};
   tiledb_config.home_ = config->get_temp_dir().c_str();
   REQUIRE(tiledb_ctx_init(&tiledb_ctx, &tiledb_config) == TILEDB_OK);
   REQUIRE(tiledb_workspace_create(tiledb_ctx, config->workspace_.c_str()) == TILEDB_OK);
@@ -337,8 +336,7 @@ void create_workspace(BenchmarkConfig* config) {
 
 void delete_arrays(BenchmarkConfig* config) {
   TileDB_CTX* tiledb_ctx;
-  TileDB_Config tiledb_config;
-  memset(&tiledb_config, 0, sizeof(TileDB_Config));
+  TileDB_Config tiledb_config = {};
   tiledb_config.home_ = config->get_temp_dir().c_str();
   REQUIRE(tiledb_ctx_init(&tiledb_ctx, &tiledb_config) == TILEDB_OK);
   for(auto dir : get_dirs(tiledb_ctx, config->workspace_)) {
@@ -372,8 +370,7 @@ void create_arrays(BenchmarkConfig* config, int i) {
                                   config->attribute_data_types_.data()) == TILEDB_OK);
 
   TileDB_CTX* tiledb_ctx;
-  TileDB_Config tiledb_config;
-  memset(&tiledb_config, 0, sizeof(TileDB_Config));
+  TileDB_Config tiledb_config = {};
   tiledb_config.home_ = config->get_temp_dir().c_str();
   REQUIRE(tiledb_ctx_init(&tiledb_ctx, &tiledb_config) == TILEDB_OK);
   REQUIRE(tiledb_array_create(tiledb_ctx, &array_schema) == TILEDB_OK);
@@ -383,8 +380,7 @@ void create_arrays(BenchmarkConfig* config, int i) {
 
 void write_arrays(BenchmarkConfig* config, int i) {
   TileDB_CTX* tiledb_ctx;
-  TileDB_Config tiledb_config;
-  memset(&tiledb_config, 0, sizeof(TileDB_Config));
+  TileDB_Config tiledb_config = {};
   tiledb_config.home_ = config->get_temp_dir().c_str();
   tiledb_config.write_method_ = config->io_write_mode_;
   REQUIRE(tiledb_ctx_init(&tiledb_ctx, &tiledb_config) == TILEDB_OK);
@@ -406,8 +402,7 @@ void write_arrays(BenchmarkConfig* config, int i) {
 
 void read_arrays(BenchmarkConfig* config, int i) {
   TileDB_CTX* tiledb_ctx;
-  TileDB_Config tiledb_config;
-  memset(&tiledb_config, 0, sizeof(TileDB_Config));
+  TileDB_Config tiledb_config = {};
   tiledb_config.home_ = config->get_temp_dir().c_str();
   tiledb_config.read_method_ = config->io_read_mode_;
   REQUIRE(tiledb_ctx_init(&tiledb_ctx, &tiledb_config) == TILEDB_OK);
@@ -555,8 +550,7 @@ void print_array_schema(TileDB_CTX* tiledb_ctx, const std::string& array) {
 
 void print_fragment_sizes(BenchmarkConfig* config, bool human_readable_sizes) {
   TileDB_CTX* tiledb_ctx;
-  TileDB_Config tiledb_config;
-  memset(&tiledb_config, 0, sizeof(TileDB_Config));
+  TileDB_Config tiledb_config = {};
   tiledb_config.home_ = config->get_temp_dir().c_str();
   REQUIRE(tiledb_ctx_init(&tiledb_ctx, &tiledb_config) == TILEDB_OK);
 


### PR DESCRIPTION
Fix for g++ being stricter than clang, also does not like memset on structs.