### PR TITLE
Refine algorithm to get azure account and key from cli

### DIFF
--- a/.github/scripts/run_dfs_tests.sh
+++ b/.github/scripts/run_dfs_tests.sh
@@ -106,6 +106,9 @@ elif [[ $INSTALL_TYPE == azurite ]]; then
   tiledb_utils_tests "az://test@devstoreaccount1.blob.core.windows.net/$TEST" &&
   $CMAKE_BUILD_DIR/test/test_azure_blob_storage --test-dir "az://test@devstoreaccount1.blob.core.windows.net/$TEST" &&
   $CMAKE_BUILD_DIR/test/test_storage_buffer --test-dir "az://test@devstoreaccount1.blob.core.windows.net/$TEST" &&
+  TEMP_VAR=$AZURE_STORAGE_ACCOUNT && unset AZURE_STORAGE_ACCOUNT &&
+  $CMAKE_BUILD_DIR/test/test_storage_buffer --test-dir "az://test@devstoreaccount1.blob.core.windows.net/$TEST" &&
+  AZURE_STORAGE_ACCOUNT=$TEMP_VAR
   $GITHUB_WORKSPACE/examples/run_examples.sh "az://test@devstoreaccount1.blob.core.windows.net/$TEST"
 
 elif [[ $INSTALL_TYPE == aws ]]; then

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -88,7 +88,7 @@ static std::string get_account_key(const std::string& account_name) {
   // Try via az CLI `az storage account keys list -o tsv --account-name <account_name>`
   // Example output :
   // %az storage account keys list -o tsv --account-name xxx
-  // None	key1	FULL	abcdefgDYrCB5B3+tHzPMNjRy3pCLh1QMh4Fcd0xP316V+t6wAfTq1dS1QpCwyO60exkQXDPl0q2I/FTabcdef==
+  // None	key1	FULL	abCdEfgAbcdeF===
   std::string keys = run_command("az storage account keys list -o tsv --account-name " + account_name);
   std::string account_key;
 

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -85,18 +85,14 @@ static std::string get_account_key(const std::string& account_name) {
     }
   }
 
-  // Try via az CLI `az storage account keys list -o tsv --account-name <account_name>`
-  // Example output :
-  // %az storage account keys list -o tsv --account-name xxx
-  // None	key1	FULL	abCdEfgAbcdeF===
-  std::string keys = run_command("az storage account keys list -o tsv --account-name " + account_name);
+  // Try retrieving first account key via az CLI
   std::string account_key;
-
-  if (keys.length() > 1) {
-    // Get the first key available
-    std::regex pattern(".*key1\\s.*\\s(.*)\\r?\\n+.*\\r?\\n+");
+  std::string key1 = run_command("az storage account keys list --query \"[?keyName == 'key1'].value | [0]\" -o tsv --account-name " + account_name);
+  if (key1.length() > 1) {
+    // Remove newlines
+    std::regex pattern("(.*)\\r?\\n?");
     std::smatch match;
-    if (std::regex_match(keys, match, pattern) && match.ready() && !match.empty() && match.size() == 2) {
+    if (std::regex_match(key1, match, pattern) && match.ready() && !match.empty() && match.size() == 2) {
       try {
         auto matched = match[1].str();
         // Check if it is really an encoded key

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -107,12 +107,12 @@ static std::string get_account_key(const std::string& account_name) {
       }
     }
   }
-
+  
   return account_key;
 }
 
 static std::string get_sas_token(const std::string& account_name) {
-  // Try environment variables AZURE_STORAGE_ACCOUNT and AZURE_SAS_KEY if get_account_key() failed
+  // Try environment variables AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY first
   char *az_storage_ac_name = getenv("AZURE_STORAGE_ACCOUNT");
   if (!az_storage_ac_name || (az_storage_ac_name && account_name.compare(az_storage_ac_name) == 0)) {
     char *key = getenv("AZURE_STORAGE_SAS_TOKEN");
@@ -206,10 +206,6 @@ AzureBlob::AzureBlob(const std::string& home) {
   }
 
   std::shared_ptr<storage_account> account = std::make_shared<storage_account>(azure_account, cred, /* use_https */true, get_blob_endpoint());
-  if (account == nullptr) {
-    throw std::system_error(EIO, std::generic_category(), "Could not create azure storage account=" + azure_account + ". " +
-                            "Try setting environment variables AZURE_STORAGE_KEY or AZURE_STORAGE_SAS_TOKEN before restarting operation");
-  }
 
   std::string ca_certs_location = locate_ca_certs();
   if (ca_certs_location.empty()) {
@@ -231,6 +227,8 @@ AzureBlob::AzureBlob(const std::string& home) {
 
   working_dir_ = get_path(path_uri.path());
 
+  adls_client_ = std::make_shared<azure::storage_adls::adls_client>(account, std::thread::hardware_concurrency()/2, false);
+
   // Set default buffer sizes, overridden with env vars TILEDB_DOWNLOAD_BUFFER_SIZE and TILEDB_UPLOAD_BUFFER_SIZE
   download_buffer_size_ = constants::default_block_size; // 8M
   upload_buffer_size_ = constants::default_block_size; // 8M
@@ -251,12 +249,20 @@ int AzureBlob::set_working_dir(const std::string& dir) {
 }
 
 bool AzureBlob::path_exists(const std::string& path) {
-  bool exists = blob_client_wrapper_->blob_exists(container_name_, get_path(path));
-  if (!exists && path[path.size()-1] == '/') {
+  auto blob_property = blob_client_wrapper_->get_blob_property(container_name_, get_path(path));
+  if (blob_property.valid()) {
+    if (blob_property.content_type.empty() && path.back() == '/') {
+      return true;
+    } else if (!blob_property.content_type.empty() && path.back() != '/') {
+      return true;
+    }
+  } else if (path.back() == '/') {
+    // Check directories in non-hierarchical namespaces by checking for children as they are not explicitly
+    // created as in hierarchical namespaces
     auto response = blob_client_wrapper_->list_blobs_segmented(container_name_, "/",  "", get_path(path), 1);
-    exists = response.blobs.size() > 0;
+    return response.blobs.size() > 0;
   }
-  return exists;
+  return false;
 }
 
 std::string AzureBlob::real_dir(const std::string& dir) {
@@ -285,20 +291,27 @@ int AzureBlob::create_dir(const std::string& dir) {
 
 int AzureBlob::delete_dir(const std::string& dir) {
   int rc = TILEDB_FS_OK;
-  std::string continuation_token = "";
-  auto response = blob_client_wrapper_->list_blobs_segmented(container_name_, "/",  continuation_token, slashify(get_path(dir)), INT_MAX);
-  do {
-    for (auto i=0u; i<response.blobs.size(); i++) {
-      if (response.blobs[i].is_directory) {
-        delete_dir(response.blobs[i].name);
-      } else {
-        blob_client_wrapper_->delete_blob(container_name_, response.blobs[i].name);
-        if (blob_client_wrapper_->blob_exists(container_name_, response.blobs[i].name)) {
-          AZ_BLOB_ERROR("File still exists after deletion", response.blobs[i].name);
+  adls_client_->delete_directory(container_name_, get_path(dir));
+  if (errno > 0) {
+    // Try again using the blob client directly for non-hierarchical filesystems
+    std::string continuation_token = "";
+    auto bclient = reinterpret_cast<blob_client *>(blob_client_.get());
+    auto response = blob_client_wrapper_->list_blobs_segmented(container_name_, "/",  continuation_token,
+                                                               slashify(get_path(dir)), INT_MAX);
+    do {
+      for (auto i=0u; i<response.blobs.size(); i++) {
+        if (response.blobs[i].is_directory) {
+          delete_dir(response.blobs[i].name);
+        } else {
+          auto result = bclient->delete_blob(container_name_, response.blobs[i].name, false).get();
+          if (!result.success()) {
+            AZ_BLOB_ERROR(result.error().message, response.blobs[i].name);
+            rc = TILEDB_FS_ERR;
+          }
         }
       }
-    }
-  } while (!continuation_token.empty());
+    } while (!continuation_token.empty());
+  }
   return rc;
 }
 
@@ -349,15 +362,15 @@ int AzureBlob::delete_file(const std::string& filename) {
 
 ssize_t AzureBlob::file_size(const std::string& filename) {
   auto blob_property = blob_client_wrapper_->get_blob_property(container_name_, get_path(filename));
-  if (blob_property.valid()) {
-#ifdef DEBUG
+  if (blob_property.valid() && !blob_property.content_type.empty()) {
+#if 0
     if (filename.find_last_of(".json") != std::string::npos) {
       std::cerr << "Blob " << filename << " md5=" << blob_property.content_md5 << " size=" << blob_property.size<< std::endl;
     }
 #endif
     return blob_property.size;
   } else {
-#ifdef DEBUG
+#if 0
     std::cerr << "No blob properties found for file=" << filename << std::endl;
 #endif
     return TILEDB_FS_ERR;


### PR DESCRIPTION
In the case where the user has not set environment variables, `AZURE_ACCOUNT_NAME` and `AZURE_ACCOUNT_KEY` or the `AZURE_ACCOUNT_NAME` does not match the URI, we resort to trying to figure out the account key using the `azure cli`. This failed because the cli had changed the output for the keys. Have resorted to using a regular expression instead that looks for `key1`. Also added a check to validate that the match is an encoded key.

Added a unit test to test this scenario when run on azurite.