### PR TITLE
Fix for "GenomicsDB failing queries with an azure workspace that has ~10000 very small fragments"

### DIFF
--- a/.github/scripts/run_dfs_tests.sh
+++ b/.github/scripts/run_dfs_tests.sh
@@ -42,11 +42,13 @@ check_results_from_examples() {
 
 run_azure_tests() {
   source $1
-  echo "Running with $1 and TEST_DIR=$TEST"
+  echo "Running TEST_DIR=$TEST"
   echo "az schema utils test" && tiledb_utils_tests "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
     echo "az schema storage test" && $CMAKE_BUILD_DIR/test/test_azure_blob_storage --test-dir "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
     echo "az schema storage buffer test" && $CMAKE_BUILD_DIR/test/test_storage_buffer --test-dir "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
     echo "az schema examples" && time $GITHUB_WORKSPACE/examples/run_examples.sh "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" &&
+    echo "az schema small size storage test" &&
+    (TILEDB_MAX_STREAM_SIZE=32 $CMAKE_BUILD_DIR/test/test_azure_blob_storage --test-dir "az://$AZURE_CONTAINER_NAME@$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$TEST" [read-write-small] || echo "az schema small size storage test failed") &&
     echo "Running with $1 DONE" &&
     check_results_from_examples
 }

--- a/core/EnvironmentVariables.md
+++ b/core/EnvironmentVariables.md
@@ -17,4 +17,4 @@ The use of these Environment Variables will alter the behavior of TileDB. These 
      gs:// URLs, by default use the GCS SDK Client. But, this behavior can be overridden to use Google HDFS Connector if necesary.
 
 * TILEDB_MAX_STREAM_SIZE
-     For azure blob storage, use download_blob_to_stream to read lengths < TILEDB_MAX_STREAM_SIZE. If this is not set, the default is 32 bytes defined in core/include/storage_manager/storage_azure_blob.h.
+     For azure blob storage, use download_blob_to_stream to read lengths < TILEDB_MAX_STREAM_SIZE. If this is not set, the default is 1024 bytes defined in core/include/storage_manager/storage_azure_blob.h.

--- a/core/include/storage_manager/storage_azure_blob.h
+++ b/core/include/storage_manager/storage_azure_blob.h
@@ -134,7 +134,7 @@ class AzureBlob : public StorageCloudFS {
     }
   };
 
-  size_t max_stream_size_ = 32;
+  size_t max_stream_size_ = 1024;
 
   std::string get_path(const std::string& path);
 

--- a/core/include/storage_manager/storage_azure_blob.h
+++ b/core/include/storage_manager/storage_azure_blob.h
@@ -134,7 +134,7 @@ class AzureBlob : public StorageCloudFS {
     }
   };
 
-  size_t max_stream_size = 32;
+  size_t max_stream_size_ = 32;
 
   std::string get_path(const std::string& path);
 

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -390,7 +390,9 @@ int AzureBlob::read_from_file(const std::string& filename, off_t offset, void *b
       read_result = bclient->download_blob_to_buffer(container_name_, path, offset, length, reinterpret_cast<char *>(buffer), std::thread::hardware_concurrency()/2).get();
     } catch (const std::exception& ex) {
       // Catch random exceptions from download_blob_to_buffer. Bug??
-      std::string message = "Random error from azure sdk with the download_blob_to_buffer api : " + std::string(ex.what()) + "\n Tune using TILEDB_MAX_STREAM_SIZE environment variable";
+      std::string message = "Random error from azure sdk with the download_blob_to_buffer api : "
+          + std::string(ex.what()) + "\n Try using the download_blob_to_stream api instead. max_stream_size="
+          + std::to_string(max_stream_size_) + " Tune using TILEDB_MAX_STREAM_SIZE environment variable";
       AZ_BLOB_ERROR(message, filename);
       return TILEDB_FS_ERR;
     }

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -391,8 +391,9 @@ int AzureBlob::read_from_file(const std::string& filename, off_t offset, void *b
     } catch (const std::exception& ex) {
       // Catch random exceptions from download_blob_to_buffer. Bug??
       std::string message = "Random error from azure sdk with the download_blob_to_buffer api : "
-          + std::string(ex.what()) + "\n Try using the download_blob_to_stream api instead. max_stream_size="
-          + std::to_string(max_stream_size_) + "bytes. Tune using TILEDB_MAX_STREAM_SIZE environment variable to override max_stream_size in bytes";
+          + std::string(ex.what()) + "\n current max_stream_size="
+          + std::to_string(max_stream_size_) + "bytes. "
+          + "Try increasing the max_stream_size using the TILEDB_MAX_STREAM_SIZE environment variable in bytes";
       AZ_BLOB_ERROR(message, filename);
       return TILEDB_FS_ERR;
     }

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -231,7 +231,7 @@ AzureBlob::AzureBlob(const std::string& home) {
 
   auto max_stream_size_var = getenv("TILEDB_MAX_STREAM_SIZE");
   if (max_stream_size_var) {
-    max_stream_size = std::stoll(max_stream_size_var);
+    max_stream_size_ = std::stoll(max_stream_size_var);
   }
 }
 
@@ -382,7 +382,7 @@ int AzureBlob::read_from_file(const std::string& filename, off_t offset, void *b
   auto bclient = reinterpret_cast<blob_client *>(blob_client_.get());
   storage_outcome<void> read_result;
   // Heuristic: if the file can be contained in a block use download_blob_to_stream(), otherwise use the parallel download_blob_to_buffer()
-  if (length <= max_stream_size) {
+  if (length <= max_stream_size_) {
     omemstream os_buf(buffer, length);
     read_result = bclient->download_blob_to_stream(container_name_, path, offset, length, os_buf).get();
   } else {

--- a/core/src/storage_manager/storage_azure_blob.cc
+++ b/core/src/storage_manager/storage_azure_blob.cc
@@ -392,7 +392,7 @@ int AzureBlob::read_from_file(const std::string& filename, off_t offset, void *b
       // Catch random exceptions from download_blob_to_buffer. Bug??
       std::string message = "Random error from azure sdk with the download_blob_to_buffer api : "
           + std::string(ex.what()) + "\n Try using the download_blob_to_stream api instead. max_stream_size="
-          + std::to_string(max_stream_size_) + " Tune using TILEDB_MAX_STREAM_SIZE environment variable";
+          + std::to_string(max_stream_size_) + "bytes. Tune using TILEDB_MAX_STREAM_SIZE environment variable to override max_stream_size in bytes";
       AZ_BLOB_ERROR(message, filename);
       return TILEDB_FS_ERR;
     }

--- a/test/src/storage_manager/test_azure_blob_storage.cc
+++ b/test/src/storage_manager/test_azure_blob_storage.cc
@@ -229,6 +229,22 @@ TEST_CASE_METHOD(AzureBlobTestFixture, "Test AzureBlob read/write file", "[read-
   free(buffer);
 }
 
+TEST_CASE_METHOD(AzureBlobTestFixture, "Test performance of AzureBlob reads of small files", "[read-write-small]") {
+  if (azure_blob == nullptr) {
+    return;
+  }
+  uint num_iterations = 20;
+  std::string test_dir("read_write_small");
+  std::vector<int> buffer(100, 22);
+  for (auto i=0L; i<num_iterations; i++) {
+    std::string filename = test_dir+"/"+std::to_string(i);
+    CHECK_RC(azure_blob->write_to_file(filename, buffer.data(), buffer.size()*sizeof(int)), TILEDB_FS_OK);
+    CHECK_RC(azure_blob->close_file(filename), TILEDB_FS_OK);
+  }
+  for (auto i=0L; i<num_iterations; i++) {
+    CHECK_RC(azure_blob->read_from_file(test_dir+"/"+std::to_string(i), 0, buffer.data(), buffer.size()*sizeof(int)), TILEDB_FS_OK);
+  }
+}
 
 TEST_CASE_METHOD(AzureBlobTestFixture, "Test AzureBlob large read/write file", "[read-write-large]") {
   if (azure_blob == nullptr) {

--- a/test/src/storage_manager/test_azure_blob_storage.cc
+++ b/test/src/storage_manager/test_azure_blob_storage.cc
@@ -229,20 +229,20 @@ TEST_CASE_METHOD(AzureBlobTestFixture, "Test AzureBlob read/write file", "[read-
   free(buffer);
 }
 
-TEST_CASE_METHOD(AzureBlobTestFixture, "Test performance of AzureBlob reads of small files", "[read-write-small]") {
+/* Test fails on Centos7 with TILEDB_MAX_STREAM_SIZE=32, but succeeds on Ubuntu and MacOS! */
+TEST_CASE_METHOD(AzureBlobTestFixture, "Test performance of AzureBlob reads of small files", "[.][!mayfail][read-write-small]") {
   if (azure_blob == nullptr) {
     return;
   }
-  uint num_iterations = 20;
+  uint num_iterations = 1500;
   std::string test_dir("read_write_small");
   std::vector<int> buffer(100, 22);
+
   for (auto i=0L; i<num_iterations; i++) {
     std::string filename = test_dir+"/"+std::to_string(i);
-    CHECK_RC(azure_blob->write_to_file(filename, buffer.data(), buffer.size()*sizeof(int)), TILEDB_FS_OK);
-    CHECK_RC(azure_blob->close_file(filename), TILEDB_FS_OK);
-  }
-  for (auto i=0L; i<num_iterations; i++) {
-    CHECK_RC(azure_blob->read_from_file(test_dir+"/"+std::to_string(i), 0, buffer.data(), buffer.size()*sizeof(int)), TILEDB_FS_OK);
+    REQUIRE(azure_blob->write_to_file(filename, buffer.data(), buffer.size()*sizeof(int)) == TILEDB_FS_OK);
+    REQUIRE(azure_blob->close_file(filename) == TILEDB_FS_OK);
+    REQUIRE(azure_blob->read_from_file(test_dir+"/"+std::to_string(i), 0, buffer.data(), buffer.size()*sizeof(int)) == TILEDB_FS_OK);
   }
 }
 

--- a/test/src/storage_manager/test_azure_blob_storage.cc
+++ b/test/src/storage_manager/test_azure_blob_storage.cc
@@ -210,10 +210,8 @@ TEST_CASE_METHOD(AzureBlobTestFixture, "Test AzureBlob read/write file", "[read-
   CHECK_RC(azure_blob->read_from_file(test_dir+"/foo", 0, buffer, 11), TILEDB_FS_OK);
   CHECK(((char *)buffer)[10] == 'e');
 
-  REQUIRE(setenv("TILEDB_MAX_STREAM_SIZE", "4", 0) == 0);
   CHECK_RC(azure_blob->read_from_file(test_dir+"/foo", 0, buffer, 11), TILEDB_FS_OK);
   CHECK(((char *)buffer)[10] == 'e');
-  REQUIRE(unsetenv("TILEDB_MAX_STREAM_SIZE") == 0);
 
   CHECK_RC(azure_blob->close_file(test_dir+"/foo"), TILEDB_FS_OK);
   CHECK_RC(azure_blob->delete_file(test_dir+"/foo"), TILEDB_FS_OK);
@@ -234,7 +232,7 @@ TEST_CASE_METHOD(AzureBlobTestFixture, "Test performance of AzureBlob reads of s
   if (azure_blob == nullptr) {
     return;
   }
-  uint num_iterations = 1500;
+  uint num_iterations = 512; // May have to increase iterations to reproduce failure on Centos 7, can go to num_iterations=2000!
   std::string test_dir("read_write_small");
   std::vector<int> buffer(100, 22);
 


### PR DESCRIPTION
The workaround is to consolidate the fragments. But, it should not fail with a `Resource Not Available` exception either.

The fix is to bump up the default size to 1024 for using azure's [download to stream api ](https://github.com/OmicsDataAutomation/azure-storage-cpplite/blob/1d3f1a41e97f6070a6e9784b30366eb3706b2f54/include/blob/blob_client.h#L109) instead of the [download to buffer api.](https://github.com/OmicsDataAutomation/azure-storage-cpplite/blob/1d3f1a41e97f6070a6e9784b30366eb3706b2f54/include/blob/blob_client.h#L121) This default size can probably be bumped up even higher, but that will be subject to further testing and real usage. We catch this exception now in AzureBlob::read_from_file() and return an appropriate error message asking the user to use env `TILEDB_MAX_STREAM_SIZE` to override the default stream size.

Tried writing unit tests to cover the exception case, but it does not seem to trigger on either Ubuntu or macOS on GitHub Actions, but is reproducible on Centos 7 very easily!