### PR TITLE
awssdk suppress for GNU c++ 12

### DIFF
--- a/cmake/Modules/FindS3Client.cmake
+++ b/cmake/Modules/FindS3Client.cmake
@@ -87,6 +87,10 @@ elseif(NOT AWSSDK_FOUND)
     -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
     DEPENDS aws-checksums-build)
 
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
+  endif()
+
   ExternalProject_Add(awssdk-build
     PREFIX ${AWSSDK_PREFIX}
     URL ${AWSSDK_URL}
@@ -108,7 +112,8 @@ elseif(NOT AWSSDK_FOUND)
     -DCMAKE_INSTALL_PREFIX=${AWSSDK_PREFIX}
     -DCMAKE_PREFIX_PATH=${AWSSDK_PREFIX}
     -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
-    -DCMAKE_CXX_FLAGS="-Wno-maybe-uninitialized")
+    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS})
+    
 
   add_dependencies(awssdk-build aws-c-common-build)
   add_dependencies(awssdk-build aws-c-event-stream-build)

--- a/cmake/Modules/FindS3Client.cmake
+++ b/cmake/Modules/FindS3Client.cmake
@@ -88,7 +88,7 @@ elseif(NOT AWSSDK_FOUND)
     DEPENDS aws-checksums-build)
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized -Wno-deprecated-declaration")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized -Wno-deprecated-declarations")
   endif()
 
   ExternalProject_Add(awssdk-build

--- a/cmake/Modules/FindS3Client.cmake
+++ b/cmake/Modules/FindS3Client.cmake
@@ -107,7 +107,8 @@ elseif(NOT AWSSDK_FOUND)
     -DCMAKE_BUILD_TYPE=Release
     -DCMAKE_INSTALL_PREFIX=${AWSSDK_PREFIX}
     -DCMAKE_PREFIX_PATH=${AWSSDK_PREFIX}
-    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR})
+    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
+    -DCMAKE_CXX_FLAGS="-Wno-maybe-uninitialized")
 
   add_dependencies(awssdk-build aws-c-common-build)
   add_dependencies(awssdk-build aws-c-event-stream-build)

--- a/cmake/Modules/FindS3Client.cmake
+++ b/cmake/Modules/FindS3Client.cmake
@@ -88,7 +88,7 @@ elseif(NOT AWSSDK_FOUND)
     DEPENDS aws-checksums-build)
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized -Wno-deprecated-declaration")
   endif()
 
   ExternalProject_Add(awssdk-build


### PR DESCRIPTION
It allows to genomicsdb to compile with c++ 12 which Ubuntu Lunar's build essentials install. When the error is suppressed, it compiles which makes it compatible with Ubuntu 23.04. I haven't tried the change on docker side to see whether it compiles or not. So I will firstly try that.