### PR TITLE
Fix build issues with crc32c  on arm64 architecture on Linux

### DIFF
--- a/cmake/Modules/FindGCSClient.cmake
+++ b/cmake/Modules/FindGCSClient.cmake
@@ -88,7 +88,7 @@ elseif(NOT GCSSDK_FOUND)
 
   ExternalProject_Add(crc32-build
     PREFIX ${GCSSDK_PREFIX}
-    URL "https://github.com/google/crc32c/archive/1.1.0.tar.gz"
+    URL "https://github.com/google/crc32c/archive/1.1.2.tar.gz"
     CMAKE_ARGS
         -DBUILD_SHARED_LIBS=OFF
         -DCRC32C_BUILD_TESTS=OFF


### PR DESCRIPTION
Fix issue by moving the crc32c source version to a later one while building gcsdk on arm64 linux machines. See https://github.com/GenomicsDB/GenomicsDB/issues/204#issuecomment-1606212673.