### PR TITLE
Optimize filter expression support for tiledb attributes with variable fields and other fixes.

### DIFF
--- a/core/include/codec/codec.h
+++ b/core/include/codec/codec.h
@@ -229,7 +229,7 @@ class Codec {
 
   std::string dl_error_;
 #ifdef __APPLE__
-  std::vector<std::string> dl_paths_ = {"/usr/local/Cellar/lib/", "/usr/local/lib/", "/usr/lib/", ""};
+  std::vector<std::string> dl_paths_ = {"/opt/homebrew/lib/", "/usr/local/Cellar/lib/", "/usr/local/lib/", "/usr/lib/", ""};
 #elif __linux__
   std::vector<std::string> dl_paths_ = {"/usr/lib64/", "/usr/lib/", ""};
 #else

--- a/core/include/expressions/expression.h
+++ b/core/include/expressions/expression.h
@@ -246,15 +246,25 @@ class OprtSplitCompareAll : public mup::IOprtBin {
     *ret = (mup::bool_type)false;
 
     // A vector is represented as a matrix in muparserx with nCols=1
-    if (with.length() > 0 && input.GetRows()/2+1u == with.length()) {
-      *ret = (mup::bool_type)true;
-      for (int i=0, j=0; i<input.GetRows(); i++) {
-        if (i%2 == 0) {
-          if (input.At(i).GetType() != 'i' || input.At(i).GetInteger() != with[j++]-'0') {
-            *ret = (mup::bool_type)false;
-            break;
+    if (with.length() > 0) {
+      if (input.GetRows()+1u == with.length()*2) { // e.g. input has a delimiter, e.g GT with Ploidy
+        *ret = (mup::bool_type)true;
+        for (int i=0, j=0; i<input.GetRows(); i++) {
+          if (i%2 == 0) {
+            if (input.At(i).GetType() != 'i' || input.At(i).GetInteger() != with[j++]-'0') {
+              *ret = (mup::bool_type)false;
+              break;
+            }
           }
         }
+      } else if (input.GetRows() == with.length()) { // e.g input without delimiters, e.g. GT without Ploidy
+        *ret = (mup::bool_type)true;
+         for (int i=0; i<input.GetRows(); i++) {
+            if (input.At(i).GetType() != 'i' || input.At(i).GetInteger() != with[i]-'0') {
+              *ret = (mup::bool_type)false;
+              break;
+            }
+         }
       }
     }
   }

--- a/core/include/expressions/expression.h
+++ b/core/include/expressions/expression.h
@@ -61,7 +61,6 @@ extern std::string tiledb_expr_errmsg;
 
 //Forward declaration
 class ArrayReadState;
-class SplitCompare;
 
 class Expression {
  public:

--- a/core/src/expressions/expression.cc
+++ b/core/src/expressions/expression.cc
@@ -58,6 +58,9 @@ Expression::Expression(std::string expression, std::vector<std::string> attribut
     EXPRESSION_ERROR("Expression parsing for dense arrays not yet implemented");
   } else if (expression_.size() != 0) {
     parser_->EnableOptimizer(true);
+
+    // muparser takes full control of DefineFun/Oprt pointers
+    // Do not release them.
     parser_->DefineFun(new SplitCompare);
     parser_->DefineOprt(new OprtSplitCompare);
     parser_->DefineOprt(new OprtSplitCompareAll);
@@ -84,7 +87,7 @@ Expression::Expression(std::string expression, std::vector<std::string> attribut
 void Expression::add_attribute(std::string name) {
   int attribute_id = array_schema_->attribute_id(name);
   int attribute_type = array_schema_->type(attribute_id);
-  int attribute_cell_val_num = array_schema_->cell_val_num(attribute_id)==TILEDB_VAR_NUM?0:array_schema_->cell_val_num(attribute_id);
+  int attribute_cell_val_num = array_schema_->cell_val_num(attribute_id)==TILEDB_VAR_NUM?0:get_cell_val_num(name);
 
   switch (attribute_type) {
     case TILEDB_CHAR: {

--- a/core/src/expressions/expression.cc
+++ b/core/src/expressions/expression.cc
@@ -207,7 +207,7 @@ void Expression::assign_fixed_cell_values(const int attribute_id, void** buffers
                                           const uint64_t buffer_index, const uint64_t position) {
   auto& attribute_name = array_schema_->attribute(attribute_id);
   auto attribute_type = array_schema_->type(attribute_id);
-  long num_cells = array_schema_->cell_val_num(attribute_id);
+  long num_cells = get_cell_val_num(attribute_name);
   switch (attribute_type) {
     case TILEDB_CHAR: {
       attribute_map_[attribute_name] = mup::string_type(get_value<char>(buffers[buffer_index], position*num_cells), num_cells);
@@ -302,7 +302,7 @@ bool Expression::evaluate_cell(void** buffers, size_t* buffer_sizes, int64_t* po
     int attribute_id = array_schema_->attribute_id(attributes_[i]);
     if (attribute_map_.find(attributes_[i]) != attribute_map_.end()) {
       try {
-        switch (array_schema_->cell_val_num(attribute_id)) {
+        switch (get_cell_val_num(attributes_[i])) {
           case 1:
             assign_single_cell_value(attribute_id, buffers, j, position);
             break;

--- a/core/src/expressions/expression.cc
+++ b/core/src/expressions/expression.cc
@@ -274,15 +274,16 @@ void Expression::assign_var_cell_values(const int attribute_id, void** buffers, 
         default:
           throw std::range_error("Attribute Type " + std::to_string(attribute_type) + " not supported in expressions");
       }
-      parser_->RemoveVar(attribute_name);
-      assert(!parser_->IsVarDefined(attribute_name));
-      mup::Value x_array(mup::int_type(info.second), mup::int_type(0));
-      for (auto i=0u; i<info.second; i++) {
-        x_array.At(i) = get_single_cell_value(attribute_type, buffers, buffer_index+1, info.first+i);
+      if (attribute_map_[attribute_name].GetRows() != (int)info.second) {
+        parser_->RemoveVar(attribute_name);
+        assert(!parser_->IsVarDefined(attribute_name));
+        mup::Value x_array(mup::int_type(info.second), mup::int_type(0));
+        attribute_map_[attribute_name] = std::move(x_array);
+        parser_->DefineVar(attribute_name, (mup::Variable)&(attribute_map_[attribute_name]));
       }
-      assert(x_array.IsMatrix());
-      attribute_map_[attribute_name] = std::move(x_array);
-      parser_->DefineVar(attribute_name, (mup::Variable)&(attribute_map_[attribute_name]));
+      for (auto i=0u; i<info.second; i++) {
+        attribute_map_[attribute_name].At(i) = get_single_cell_value(attribute_type, buffers, buffer_index+1, info.first+i);
+      }
     }
   }
 }

--- a/test/src/expressions/test_filter_api.cc
+++ b/test/src/expressions/test_filter_api.cc
@@ -295,3 +295,120 @@ TEST_CASE("Test genomicsdb_ws filter with read api", "[genomicsdb_ws_filter_read
     }
   }
 }
+
+TEST_CASE("Test genomicsdb demo test case", "[genomicsdb_demo]") {
+  char *workspace = getenv("GENOMICSDB_DEMO_WS");
+  if (!workspace) return;
+
+  std::string array = std::string(workspace) + "/allcontigs$1$3095677412";
+
+  std::vector<std::string> filters = {"", // zlib 38s
+    "__coords[0]==10000", // 4s
+    "__coords[0]==10000 && REF==\"T\"", // 5s
+    "__coords[0]==10000 && REF==\"T\" && ALT|=\"C\"", // 6s
+    "__coords[0]==10000 && REF==\"T\" && ALT|=\"C\" && GT[0]==1", // 7s
+    "__coords[0]==10000 && REF==\"T\" && ALT|=\"C\" && GT&=\"1|1\"", // eval true 7s
+    "__coords[0]==10000 && REF==\"C\" && ALT|=\"T\" && GT&=\"1|1\"" // eval false 7s 
+    };
+
+  const int64_t subarray[] = {0ul, 200000ul, 2000000000ul, 2100000000ul};
+
+  for (auto filter_i=0u; filter_i<filters.size(); filter_i++) {
+    // Initialize tiledb context
+    TileDB_CTX* tiledb_ctx;
+    TileDB_Config tiledb_config;
+    tiledb_config.home_ = workspace;
+
+    // Initialize Context
+    CHECK_RC(tiledb_ctx_init(&tiledb_ctx, &tiledb_config), TILEDB_OK);
+
+    Catch::Timer t;
+    t.start();
+
+    printf("Starting evaluation for %s\n", filters[filter_i].c_str());
+
+    size_t buffer_size = 4096;
+    size_t buffer_sizes[] = { buffer_size, buffer_size, buffer_size, buffer_size, buffer_size, buffer_size, buffer_size };
+    void *buffers[7];
+    auto nBuffers = sizeof(buffer_sizes)/sizeof(size_t);
+    CHECK(nBuffers == 7);
+    for (auto i=0u; i<nBuffers; i++) {
+      buffers[i] = malloc(buffer_sizes[i]);
+    }
+
+    // Initialize array
+    TileDB_ArrayIterator* tiledb_array_it;
+    CHECK_RC(tiledb_array_iterator_init_with_filter(
+        tiledb_ctx,                                       // Context
+        &tiledb_array_it,                                 // Array object
+        array.c_str(),                                    // Array name
+        TILEDB_ARRAY_READ,                                // Mode
+        subarray,                                         // Subarray
+        attributes,                                       // Subset on attributes
+        sizeof(attributes)/sizeof(char *),                // Number of attributes
+        buffers,                                          // Preallocated buffers for internal use
+        buffer_sizes,                                     // buffer_sizes
+        filters[filter_i].c_str()),
+             TILEDB_OK);
+
+    while (tiledb_array_iterator_end(tiledb_array_it) == TILEDB_OK) {
+      char* REF_val;
+      size_t REF_size;
+      CHECK_RC(tiledb_array_iterator_get_value(
+          tiledb_array_it,          // Array iterator
+          0,                        // Attribute id for REF
+          (const void**) &REF_val,  // Value
+          &REF_size),               // Value size (useful in variable-sized attributes)
+               TILEDB_OK);
+      for (auto i=0u; i<REF_size/sizeof(char); i++, REF_val++) {
+        if (!i) printf("REF=");
+        printf("%c ", *REF_val);
+      }
+      char* ALT_val;
+      size_t ALT_size;
+      CHECK_RC(tiledb_array_iterator_get_value(
+          tiledb_array_it,          // Array iterator
+          1,                        // Attribute id for ALT
+          (const void**) &ALT_val,  // Value
+          &ALT_size),               // Value size (useful in variable-sized attributes)
+               TILEDB_OK);
+      for (auto i=0u; i<ALT_size/sizeof(char); i++, ALT_val++) {
+        if (!i) printf("ALT=");
+        printf("%c ", *ALT_val);
+      }
+      int* GT_val = NULL;
+      size_t GT_size = 0;
+      CHECK_RC(tiledb_array_iterator_get_value(
+          tiledb_array_it,         // Array iterator
+          2,                       // Attribute id for GT
+          (const void**) &GT_val,  // Value
+          &GT_size),               // Value size (useful in variable-sized attributes)
+               TILEDB_OK);
+      for (auto i=0u; i<GT_size/sizeof(int); i++, GT_val++) {
+        if (!i) printf("GT=");
+        printf("%d ", *GT_val);
+      }
+      int64_t* coords = NULL;
+      size_t coords_size = 0;
+      CHECK_RC(tiledb_array_iterator_get_value(
+          tiledb_array_it,         // Array iterator
+          3,                       // Attribute id for coords
+          (const void**) &coords,  // Value
+          &coords_size),           // Value size (useful in variable-sized attributes)
+               TILEDB_OK);
+      CHECK(coords_size == 16);
+      printf("coords[0]=%lld coords[1]=%lld\n", (long long)(coords[0]), (long long)(coords[1]));
+
+      // Advance iterator
+      CHECK_RC(tiledb_array_iterator_next(tiledb_array_it), TILEDB_OK);
+    }
+
+    // Finalize the array
+    CHECK_RC(tiledb_array_iterator_finalize(tiledb_array_it), TILEDB_OK);
+
+    printf("Elapsed Time=%us for %s\n", t.getElapsedMilliseconds()/1000, filters[filter_i].c_str());
+
+    // Finalize context
+    CHECK_RC(tiledb_ctx_finalize(tiledb_ctx), TILEDB_OK);
+  }
+}


### PR DESCRIPTION
- Fix expression filter support with __coords attribute by checking on number of dimensions
- Optimize assigning values to variables that have TILEDB_VAR_NUM
- Filter support for `&=` custom operator with and without delimiters(e.g GT with or without ploidy separators)
- MacOS arm64 support, add /opt/homebrew/lib/ to `dl search paths`.