### PR TITLE
Change tiledb_array_evaluate_cell api to catch and handle errors better.

### DIFF
--- a/core/include/c_api/tiledb.h
+++ b/core/include/c_api/tiledb.h
@@ -7,6 +7,7 @@
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  * @copyright Copyright (c) 2018-2021 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -622,7 +623,7 @@ TILEDB_EXPORT int tiledb_array_skip_and_read(
    *     input buffers (there is a one-to-one correspondence).
    * @param positions The position of the cell in the buffer to be evaluated.
    *     There should be one position for each of the input buffers.
-   * @return TILEDB_OK for successful evaluation and TILEDB_ERR otherwise.
+   * @return true(1) or false(0) for successful evaluation and TILEDB_ERR(-1) otherwise.
    *     The onus is on the client to check if there was an error during
    *     evaluation when TILEB_ERR is returned.
    */

--- a/core/include/expressions/expression.h
+++ b/core/include/expressions/expression.h
@@ -7,6 +7,7 @@
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  * @copyright Copyright (c) 2019, 2022-2023 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -70,22 +71,21 @@ class Expression {
   /* ********************************* */
   Expression();
 
-  Expression(std::string expression, std::vector<std::string> attribute_vec,
-             const ArraySchema* array_schema);
+  Expression(std::string expression) : expression_(expression) {};
 
   ~Expression() {
     delete parser_;
   }
 
-  void set_array_schema(const ArraySchema *array_schema);
+  int init(const std::vector<int>& attribute_ids, const ArraySchema* array_schema);
 
   void add_attribute(std::string name);
 
   int add_expression(std::string expression);
 
-  bool evaluate_cell(void **buffers, size_t* buffer_sizes, std::vector<int64_t>& positions);
+  int evaluate_cell(void **buffers, size_t* buffer_sizes, std::vector<int64_t>& positions);
 
-  bool evaluate_cell(void** buffers, size_t* buffer_sizes, int64_t* positions);
+  int evaluate_cell(void** buffers, size_t* buffer_sizes, int64_t* positions);
 
   /**
    * Only used for unit testing.
@@ -98,6 +98,7 @@ class Expression {
   std::string expression_;
   std::vector<std::string> attributes_;
   const ArraySchema* array_schema_;
+  bool is_initialized = false;
 
   mup::ParserX *parser_ = new mup::ParserX(mup::pckALL_NON_COMPLEX | mup::pckMATRIX);
   std::map<std::string, mup::Value> attribute_map_;

--- a/core/include/expressions/expression.h
+++ b/core/include/expressions/expression.h
@@ -69,8 +69,6 @@ class Expression {
   /* ********************************* */
   /*            MUTATORS               */
   /* ********************************* */
-  Expression();
-
   Expression(std::string expression) : expression_(expression) {};
 
   ~Expression() {

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -7,6 +7,7 @@
  *
  * @copyright Copyright (c) 2016 MIT and Intel Corp.
  * @copyright Copyright (c) 2018-2021 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -797,13 +798,14 @@ int tiledb_array_evaluate_cell(
     return TILEDB_ERR;
 
   // Evaluate cell
-  if(tiledb_array->array_->evaluate_cell(buffers, buffer_sizes, positions) != TILEDB_AR_OK) {
+  int rc;
+  if((rc = tiledb_array->array_->evaluate_cell(buffers, buffer_sizes, positions)) == TILEDB_AR_ERR) {
     strcpy(tiledb_errmsg, tiledb_ar_errmsg.c_str());
     return TILEDB_ERR;
   }
 
-  // Success
-  return TILEDB_OK;
+  // true/false depending on the evaluation
+  return rc;
 }
 
 int tiledb_array_overflow(

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -546,6 +546,7 @@ int tiledb_array_apply_filter(
   // Apply filter
   if (tiledb_array->array_->apply_filter(filter_expression) != TILEDB_AR_OK) {
     strcpy(tiledb_errmsg, tiledb_ar_errmsg.c_str());
+    return TILEDB_ERR;
   }
 
   // Success

--- a/core/src/expressions/expression.cc
+++ b/core/src/expressions/expression.cc
@@ -87,7 +87,7 @@ int Expression::init(const std::vector<int>& attribute_ids, const ArraySchema* a
         }
       }
     } catch (mup::ParserError const &e) {
-      EXPRESSION_ERROR("Parser SetExpr error: " + e.GetMsg());
+      EXPRESSION_ERROR("Parser SetExpr error for expression '" + expression_ + "': " + e.GetMsg());
       return TILEDB_EXPR_ERR;
     }
     last_processed_buffer_index_.resize(attributes_.size());
@@ -164,7 +164,7 @@ void print_parser_expr_varmap(mup::ParserX *parser)
 
 struct EmptyValueException : public std::exception {
   const char* what () const throw () {
-    return "Empty Value Exception";
+    return "NYI: Filter expressions do not handle empty values yet";
   }
 };
 
@@ -332,7 +332,7 @@ int Expression::evaluate_cell(void** buffers, size_t* buffer_sizes, int64_t* pos
             assign_fixed_cell_values(attribute_id, buffers, j, position);
         }
       } catch (EmptyValueException& e) {
-        EXPRESSION_ERROR("NYI: Filter expressions do not handle empty values yet");
+        EXPRESSION_ERROR(e.what());
         return true;
       }
     }

--- a/core/src/expressions/expression.cc
+++ b/core/src/expressions/expression.cc
@@ -332,7 +332,7 @@ int Expression::evaluate_cell(void** buffers, size_t* buffer_sizes, int64_t* pos
             assign_fixed_cell_values(attribute_id, buffers, j, position);
         }
       } catch (EmptyValueException& e) {
-        EXPRESSION_ERROR("NYI: Filter expressions do not handle empty values yet" + std::string(e.what()));
+        EXPRESSION_ERROR("NYI: Filter expressions do not handle empty values yet");
         return true;
       }
     }

--- a/examples/src/tiledb_array_read_sparse_filter_1.cc
+++ b/examples/src/tiledb_array_read_sparse_filter_1.cc
@@ -6,6 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2019, 2022 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -86,7 +87,7 @@ int main(int argc, char *argv[]) {
   int64_t positions[10];
   for(int i=0; i<result_num; ++i) {
     for (int j=0; j<10; j++) positions[j] = i;
-    if (tiledb_array_evaluate_cell(tiledb_array, buffers, buffer_sizes, positions) == TILEDB_OK) {
+    if (tiledb_array_evaluate_cell(tiledb_array, buffers, buffer_sizes, positions)) {
       printf("(%" PRId64 ", %" PRId64 ")", buffer_coords[2*i], buffer_coords[2*i+1]);
       printf("\t %3d", buffer_a1[i]);
       size_t var_size = (i != result_num-1) ? buffer_a2[i+1] - buffer_a2[i] 

--- a/examples/src/tiledb_array_read_sparse_filter_2.cc
+++ b/examples/src/tiledb_array_read_sparse_filter_2.cc
@@ -6,6 +6,7 @@
  * The MIT License
  * 
  * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -83,7 +84,7 @@ int main(int argc, char *argv[]) {
     int64_t positions[1];
     for(int i=0; i<result_num; ++i) {
       positions[0] = i;
-      if (tiledb_array_evaluate_cell(tiledb_array, buffers, buffer_sizes, positions) == TILEDB_OK) {
+      if (tiledb_array_evaluate_cell(tiledb_array, buffers, buffer_sizes, positions)) {
         if(buffer_a1[i] != TILEDB_EMPTY_INT32) // Check for deletion
           printf("%3d\n", buffer_a1[i]);
       }

--- a/test/src/c_api/test_array_iterator.cc
+++ b/test/src/c_api/test_array_iterator.cc
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2019 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -234,7 +235,7 @@ TEST_CASE_METHOD(ArrayIteratorFixture, "Test sparse array iterator with filter w
   finalize_array_iterator();
 }
 
-TEST_CASE_METHOD(ArrayIteratorFixture, "Test sparse array iterator with filteri with empty value", "[sparse_array_iterator_with_filter_with_empty_value]") {
+TEST_CASE_METHOD(ArrayIteratorFixture, "Test sparse array iterator with filter with empty value", "[sparse_array_iterator_with_filter_with_empty_value]") {
   create_sparse_array("test_sparse_array_it_filter_with_empty_value");
   update_array_with_empty_attributes();  
   setup_array_iterator("ATTR_INT32 > 3");

--- a/test/src/expressions/test_expressions.cc
+++ b/test/src/expressions/test_expressions.cc
@@ -167,7 +167,7 @@ TEMPLATE_TEST_CASE_METHOD(ArrayFixture, "Test Expressions Empty", "[expressions_
   }
 }
 
-TEMPLATE_TEST_CASE_METHOD(ArrayFixture, "Test Expressions All", "[expressions_all]", char, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double) {
+TEMPLATE_TEST_CASE_METHOD(ArrayFixture, "Test Expressions All", "[expressions_all]", uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double) {
   SECTION("cell sizes = 1") {
     AF::setup(1);
     Expression expression("a1 >= 0");

--- a/test/src/expressions/test_expressions.cc
+++ b/test/src/expressions/test_expressions.cc
@@ -343,6 +343,7 @@ TEST_CASE("Test custom operator |= in Expression filters", "[custom_operators]")
   const std::string array_name = "test_custom_operator_array";
   const char *attr_names[] = { "a1" };
   std::vector<std::string> attribute_names = { "a1" };
+  std::vector<int> attribute_ids = { 0 };
   int types[2] = { TILEDB_CHAR, TILEDB_INT32 };
   int cell_val_nums[1] = { TILEDB_VAR_NUM };
 
@@ -359,7 +360,8 @@ TEST_CASE("Test custom operator |= in Expression filters", "[custom_operators]")
   size_t buffer_sizes[2] = { sizeof(buffer_offsets), sizeof(buffer) };
   int64_t positions[] = { 0 };
 
-  Expression expression("a1 |= \"A\"", attribute_names, &array_schema);
+  Expression expression("a1 |= \"A\"");
+  REQUIRE(expression.init(attribute_ids, &array_schema) == TILEDB_OK);
   REQUIRE(expression.evaluate_cell(buffers, buffer_sizes, positions)); // A|C
   positions[0] = 1;
   REQUIRE(!expression.evaluate_cell(buffers, buffer_sizes, positions)); // T|G
@@ -372,17 +374,20 @@ TEST_CASE("Test custom operator |= in Expression filters", "[custom_operators]")
 TEST_CASE_METHOD(ArrayFixture<int>, "Test custom operator &= in Expression filters", "[custom_operators]") {
   setup(2);
   SECTION("passing expression evaluation") {
-    Expression expression("a1 &= \"0/1\"", attribute_names, array_schema_);
+    Expression expression("a1 &= \"0/1\"");
+    REQUIRE(expression.init(attribute_ids, array_schema_) == TILEDB_OK);
     int64_t positions[] = { 0 };
     REQUIRE(expression.evaluate_cell(buffers, buffer_sizes, positions));
   }
   SECTION("failing expression evaluation") {
-    Expression expression("a1 &= \"1/0\"", attribute_names, array_schema_);
+    Expression expression("a1 &= \"1/0\"");
+    REQUIRE(expression.init(attribute_ids, array_schema_) == TILEDB_OK);
     int64_t positions[] = { 0 };
     REQUIRE(!expression.evaluate_cell(buffers, buffer_sizes, positions));
   }
   SECTION("another failing expression evaluation") {
-    Expression expression("a1 &= \"0\"", attribute_names, array_schema_);
+    Expression expression("a1 &= \"0\"");
+    REQUIRE(expression.init(attribute_ids, array_schema_) == TILEDB_OK);
     int64_t positions[] = { 0 };
     REQUIRE(!expression.evaluate_cell(buffers, buffer_sizes, positions));
   }
@@ -392,6 +397,7 @@ TEST_CASE("Test custom operator &= in Expression filters with delimiters", "[cus
   const std::string array_name = "test_custom_operator_array";
   const char *attr_names[] = { "a1" };
   std::vector<std::string> attribute_names = { "a1" };
+  std::vector<int> attribute_ids = { 0 };
   int types[2] = { TILEDB_INT32 };
   int cell_val_nums[1] = { 3 };
 
@@ -408,7 +414,8 @@ TEST_CASE("Test custom operator &= in Expression filters with delimiters", "[cus
   int64_t positions[] = { 0 };
 
   SECTION("with 0|1") {
-    Expression expression("a1 &= \"0|1\"", attribute_names, &array_schema);
+    Expression expression("a1 &= \"0|1\"");
+    REQUIRE(expression.init(attribute_ids, &array_schema) == TILEDB_OK);
     REQUIRE(expression.evaluate_cell(buffers, buffer_sizes, positions));
     positions[0] = 1;
     REQUIRE(!expression.evaluate_cell(buffers, buffer_sizes, positions));
@@ -418,7 +425,8 @@ TEST_CASE("Test custom operator &= in Expression filters with delimiters", "[cus
     REQUIRE(!expression.evaluate_cell(buffers, buffer_sizes, positions));
   }
   SECTION("with 20") {
-    Expression expression("a1 &= \"20\"", attribute_names, &array_schema);
+    Expression expression("a1 &= \"20\"");
+    REQUIRE(expression.init(attribute_ids, &array_schema) == TILEDB_OK);
     REQUIRE(!expression.evaluate_cell(buffers, buffer_sizes, positions));
     positions[0] = 1;
     REQUIRE(expression.evaluate_cell(buffers, buffer_sizes, positions));
@@ -428,7 +436,8 @@ TEST_CASE("Test custom operator &= in Expression filters with delimiters", "[cus
     REQUIRE(!expression.evaluate_cell(buffers, buffer_sizes, positions));
   }
   SECTION("with 3|3") {
-    Expression expression("a1 &= \"3|3\"", attribute_names, &array_schema);
+    Expression expression("a1 &= \"3|3\"");
+    REQUIRE(expression.init(attribute_ids, &array_schema) == TILEDB_OK);
     REQUIRE(!expression.evaluate_cell(buffers, buffer_sizes, positions));
     positions[0] = 1;
     REQUIRE(!expression.evaluate_cell(buffers, buffer_sizes, positions));

--- a/test/src/expressions/test_filter_api.cc
+++ b/test/src/expressions/test_filter_api.cc
@@ -261,9 +261,9 @@ TEST_CASE("Test genomicsdb_ws filter with read api", "[genomicsdb_ws_filter_read
         int rc = tiledb_array_evaluate_cell(tiledb_array, buffers, buffer_sizes, positions);
         CHECK(rc != TILEDB_ERR);
         if (i != 5) {
-          // REQUIRE(tiledb_array_evaluate_cell(tiledb_array, buffers, buffer_sizes, positions) == true);
+          REQUIRE(rc == false);
         } else {
-          //REQUIRE(tiledb_array_evaluate_cell(tiledb_array, buffers, buffer_sizes, positions) == false);
+          REQUIRE(rc == true);
           for (auto j=0; j<7; j++) {
             switch (j) {
               case 1: // REF - string

--- a/test/src/expressions/test_filter_api.cc
+++ b/test/src/expressions/test_filter_api.cc
@@ -6,6 +6,7 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2023 Omics Data Automation, Inc.
+ * @copyright Copyright (c) 2023 dātma, inc™
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -242,11 +243,13 @@ TEST_CASE("Test genomicsdb_ws filter with read api", "[genomicsdb_ws_filter_read
       for (auto i=0; i<ncells; i++) {
         // Check return buffers, there should only be one match based on the filter
         int64_t positions[] = {i, i, i, i, i, i, i };
-        INFO(std::string("Evaluating cell for cell position=") + std::to_string(i));
+        INFO(std::string("Evaluating cell for cell position=") + std::to_string(i) + " tiledb_errmsg=" + std::string(tiledb_errmsg));
+        int rc = tiledb_array_evaluate_cell(tiledb_array, buffers, buffer_sizes, positions);
+        CHECK(rc != TILEDB_ERR);
         if (i != 5) {
-          REQUIRE(tiledb_array_evaluate_cell(tiledb_array, buffers, buffer_sizes, positions) == TILEDB_ERR);
+          // REQUIRE(tiledb_array_evaluate_cell(tiledb_array, buffers, buffer_sizes, positions) == true);
         } else {
-          REQUIRE(tiledb_array_evaluate_cell(tiledb_array, buffers, buffer_sizes, positions) == TILEDB_OK);
+          //REQUIRE(tiledb_array_evaluate_cell(tiledb_array, buffers, buffer_sizes, positions) == false);
           for (auto j=0; j<7; j++) {
             switch (j) {
               case 1: // REF - string


### PR DESCRIPTION
Currently, for error conditions, the `evaluate_cell` api just logs the error and returns `true`. This is causing a little confusion especially when there are `muparserx` exceptions or when attributes not in the schema are specified. It is better to fail fast rather than ignore the errors from the usage I have seen so far. This enables the user to reformulate the filter expression and query again, especially if the error messages are informative.

These are some of the error messages returned by `tiledb_array_evaluate_cell` for a failed evaluation -

- Attribute POS in expression filter not present in the array schema
- Expression parsing for dense arrays not yet implemented
- Initialization not completed
- Only expressions evaluating to booleans is supported
- Parser evaluate error, possibly due to bad filter expression + parserException.GetMsg()
- Parser SetExpr error: + parserException.GetMsg() // A general catchall error

What is not handled yet is `empty values` that happens during deletions. In this case, we continue logging a `NYI: Filter expressions do not handle empty values yet`, but the evaluation passes.